### PR TITLE
feat: Add rendered migration body to failed model-sync test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased (2020-06-25)
+
+#### New Features
+
+* Add rendered migration body to failed model-sync test.
+
 ## v0.2.1 (2020-03-23)
 
 #### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.2.1"
+version = "0.2.2"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",


### PR DESCRIPTION
```
E           AssertionError: The models decribing the DDL of your database are out of sync with the set of steps described in the revision history. This usually means that someo
ne has made manual changes to the database's DDL, or some model has been changed without also generating a migration to describe that change.
E
E             The upgrade which would have been generated would look like:
E
E             # ### commands auto generated by Alembic - please adjust! ###
E             op.create_table('example',
E             sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
E             sa.PrimaryKeyConstraint('id'),
E             schema='youtube'
E             )
E             # ### end Alembic commands ###
E
E           assert False
```