### PR TITLE
feat: Prettify error output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased (2020-06-25)
+## 0.2.3 (2020-06-26)
+
+#### New Features
+
+* Reduce the multiple pages of traceback output to a few lines of context that are actually meaningful to a failed test.
+
+## v0.2.2 (2020-06-25)
 
 #### New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.2.2"
+version = "0.2.3"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/src/pytest_alembic/executor.py
+++ b/src/pytest_alembic/executor.py
@@ -1,4 +1,6 @@
+import contextlib
 import functools
+import io
 from dataclasses import dataclass
 from io import StringIO
 from typing import Dict, List, Optional, Union
@@ -46,7 +48,11 @@ class CommandExecutor:
 
         executable_command = getattr(alembic.command, command)
         try:
-            executable_command(self.alembic_config, *args, **kwargs)
+            # Hide the (relatively) worthless logs of the upgrade revision path, it just clogs
+            # up the logs when errors actually occur, but without providing any context.
+            buffer = io.StringIO()
+            with contextlib.redirect_stderr(buffer):
+                executable_command(self.alembic_config, *args, **kwargs)
         except alembic.util.exc.CommandError as e:
             raise RuntimeError(e)
 

--- a/src/pytest_alembic/plugin/error.py
+++ b/src/pytest_alembic/plugin/error.py
@@ -1,0 +1,34 @@
+import textwrap
+
+from _pytest._code.code import FormattedExcinfo
+
+
+class AlembicTestFailure(AssertionError):
+    def __init__(self, message, context=None):
+        super().__init__(message)
+        self.context = context
+
+
+class AlembicReprError:
+    def __init__(self, exce, item):
+        self.exce = exce
+        self.item = item
+
+    def toterminal(self, tw):
+        """Print out a custom error message to the terminal.
+        """
+        exc = self.exce.value
+        context = exc.context
+
+        if context:
+            for title, item in context:
+                tw.line(title + ":", white=True, bold=True)
+                tw.line(textwrap.indent(item, "    "), red=True)
+                tw.line("")
+
+        e = FormattedExcinfo()
+        lines = e.get_exconly(self.exce)
+
+        tw.line("Errors:", white=True, bold=True)
+        for line in lines:
+            tw.line(line, red=True, bold=True)

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -3,6 +3,8 @@ import re
 import pytest
 from _pytest import fixtures
 
+from pytest_alembic.plugin.error import AlembicReprError, AlembicTestFailure
+
 
 def collect_all_tests():
     from pytest_alembic import tests
@@ -101,3 +103,8 @@ class PytestAlembicItem(pytest.Item):
 
     def reportinfo(self):
         return (self.fspath, 0, f"[pytest-alembic] {self.name}")
+
+    def repr_failure(self, excinfo):
+        if isinstance(excinfo.value, AlembicTestFailure):
+            return AlembicReprError(excinfo, self)
+        return super().repr_failure(excinfo)


### PR DESCRIPTION
Before, this would have been many many pages of useless internal traceback context, and (depending on the length of your migration history) a page or 2 of useless alembic stderr logs.

<img width="1680" alt="Screen Shot 2020-06-26 at 11 28 20 AM" src="https://user-images.githubusercontent.com/701548/85875165-cfac1380-b7a1-11ea-9d17-f2c24b0eb696.png">
<img width="1680" alt="Screen Shot 2020-06-26 at 11 29 57 AM" src="https://user-images.githubusercontent.com/701548/85875263-f0746900-b7a1-11ea-987e-abec9c7af5e3.png">


