### PR TITLE
Fix assignment exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.3.1"
+version = "0.3.2"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/src/pytest_alembic/tests.py
+++ b/src/pytest_alembic/tests.py
@@ -91,20 +91,20 @@ def test_up_down_consistency(alembic_runner):
 
     Individually upgrade to ensure that it's clear which revision caused the failure.
     """
-    try:
-        for revision in alembic_runner.history.revisions:
+    for revision in alembic_runner.history.revisions:
+        try:
             alembic_runner.migrate_up_to(revision)
-    except RuntimeError as e:
-        raise AlembicTestFailure(
-            "Failed to upgrade through each revision individually.",
-            context=[("Failing Revision", revision), ("Alembic Error", str(e))],
-        )
+        except RuntimeError as e:
+            raise AlembicTestFailure(
+                "Failed to upgrade through each revision individually.",
+                context=[("Failing Revision", revision), ("Alembic Error", str(e))],
+            )
 
-    try:
-        for revision in reversed(alembic_runner.history.revisions):
+    for revision in reversed(alembic_runner.history.revisions):
+        try:
             alembic_runner.migrate_down_to(revision)
-    except RuntimeError as e:
-        raise AlembicTestFailure(
-            "Failed to downgrade through each revision individually.",
-            context=[("Failing Revision", revision), ("Alembic Error", str(e))],
-        )
+        except RuntimeError as e:
+            raise AlembicTestFailure(
+                "Failed to downgrade through each revision individually.",
+                context=[("Failing Revision", revision), ("Alembic Error", str(e))],
+            )


### PR DESCRIPTION
This fixes the following error when there are no revisions:

```
alembic_runner = MigrationContext(command_executor=CommandExecutor(alembic_config=<alembic.config.Config object at 0x16d773250>, stdout...tion_executor=ConnectionExecutor(connection=Engine(mysql+pymysql://root:***@localhost:3406/pytest_mock_resource_db_2)))

    @pytest.mark.alembic
    def test_up_down_consistency(alembic_runner):
        """Assert that all downgrades succeed.

        While downgrading may not be lossless operation data-wise, there’s a theory of database
        migrations that says that the revisions in existence for a database should be able to go
        from an entirely blank schema to the finished product, and back again.

        Individually upgrade to ensure that it's clear which revision caused the failure.
        """
        try:
            for revision in alembic_runner.history.revisions:
                alembic_runner.migrate_up_to(revision)
        except RuntimeError as e:
            raise AlembicTestFailure(
                "Failed to upgrade through each revision individually.",
>               context=[("Failing Revision", revision), ("Alembic Error", str(e))],
            )
E           UnboundLocalError: local variable 'revision' referenced before assignment
```
