### PR TITLE
Fix minor bugs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![CircleCI](https://img.shields.io/circleci/build/gh/schireson/pytest-alembic/master)
 [![codecov](https://codecov.io/gh/schireson/pytest-alembic/branch/master/graph/badge.svg)](https://codecov.io/gh/schireson/pytest-alembic)
-[![Documentation
-Status](https://readthedocs.org/projects/pytest-alembic/badge/?version=latest)](https://pytest-alembic.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/pytest-alembic/badge/?version=latest)](https://pytest-alembic.readthedocs.io/en/latest/?badge=latest)
 
 ## Introduction
 
@@ -75,8 +74,8 @@ itself.
   existence for a database should be able to go from an entirely blank
   schema to the finished product, and back again.
 
-- [Experimental tests
-tests](http://pytest-alembic.readthedocs.io/en/latest/experimental_tests.html)
+- [Experimental
+  tests](http://pytest-alembic.readthedocs.io/en/latest/experimental_tests.html)
 
   These tests will need to be enabled manually because their semantics or API are
   not yet guaranteed to stay the same. See the linked docs for more details!


### PR DESCRIPTION
The docs on readthedocs are broken, probably due to the line splitting in the image link. See https://pytest-alembic.readthedocs.io/en/latest/quickstart.html

![image](https://user-images.githubusercontent.com/3324881/141298360-92c55732-0eb3-4f93-80bc-c7c8e6db1149.png)
