### PR TITLE
docs: update example for insert_to

### DIFF
--- a/docs/source/custom_tests.rst
+++ b/docs/source/custom_tests.rst
@@ -13,7 +13,7 @@ Honestly, there's not much to it by this point!
 
        # Perform some very specific data setup, because this migration is sooooo complex.
        # ...
-       alembic_runner.insert_into(dict(id=1, name='foo'), tablename='tablename'))
+       alembic_runner.insert_into('tablename', dict(id=1, name='foo'))
        # Or you can optionally accept the `alembic_engine` fixture, which is a
        # sqlalchemy engine object, with which you can do whatever setup you'd like.
 


### PR DESCRIPTION
Thanks for building and maintaining this plugin! It is really useful

I found a small error in the documentation on how to use `insert_to` because the `tablename` kwarg appears to be removed:

https://github.com/schireson/pytest-alembic/blob/fac82f1742503de921d4d559bb05f99112e430e7/examples/test_migrate_up_before/test_migrations.py#L4