### PR TITLE
fix: Avoid the use of the high-level alembic command interface in mos…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased](https://github.com/schireson/pytest-alembic/compare/v0.7.0...HEAD) (2022-02-08)
+
+### Fixes
+
+* (Huge speed optimization) Avoid the use of the high-level alembic command interface in most cases. 1ae311f
+
+
 ## [v0.7.0](https://github.com/schireson/pytest-alembic/compare/v0.6.1...v0.7.0) (2021-12-21)
 
 ### ⚠ BREAKING CHANGE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.7.0"
+version = "0.8.0"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/src/pytest_alembic/tests/experimental/downgrade_leaves_no_trace.py
+++ b/src/pytest_alembic/tests/experimental/downgrade_leaves_no_trace.py
@@ -78,6 +78,9 @@ def _test_downgrade_leaves_no_trace(connection, alembic_runner: MigrationContext
         # So we need to proceed by one.
         alembic_runner.migrate_up_to(revision)
 
+        if hasattr(connection, "commit"):
+            connection.commit()
+
 
 def check_revision_cycle(alembic_runner, connection, original_revision):
     migration_context = alembic.migration.MigrationContext.configure(connection)


### PR DESCRIPTION
…t cases.

In particular, the `alembic.command.<x>` (where <x> is something like
upgrade, downgrade, or head(s)). These commands are (seemingly) intended
to be used as one-off commands because they internally create `ScriptDirectory`
objects.

Given that we execute numerous individual commands per test, that creation
step adds up leads to (with any appreciable history length) test
runtime. An `alembic upgrade head` which takes 20s can take up to 5m
before this change.

This PR switches to internally producing a `ScriptDirectory` once, and
reimplementing some of the internals of the `alembic.command` interface
becuase there isn't a public way of providing a script to those
functions.