### PR TITLE
Fix typos in doc-strings and exception message

### DIFF
--- a/src/pytest_alembic/runner.py
+++ b/src/pytest_alembic/runner.py
@@ -236,7 +236,7 @@ def run_connection_task(engine, fn, *args, **kwargs):
     """Run a given task on the provided connect, with the correct async/sync context.
 
     Given an async engine, we need to run the task in an async execution context,
-    even though all internals are sychronous. This is how alembic suggests
+    even though all internals are synchronous. This is how alembic suggests
     running the migrations themselves, so this matches that style.
     """
     # The user may not have sqlalchemy 1.4+, and therefore may not even be able to

--- a/src/pytest_alembic/tests/default.py
+++ b/src/pytest_alembic/tests/default.py
@@ -69,7 +69,7 @@ def test_model_definitions_match_ddl(alembic_runner):
 
             if not migration_is_empty:
                 raise AlembicTestFailure(
-                    "The models decribing the DDL of your database are out of sync with the set of "
+                    "The models describing the DDL of your database are out of sync with the set of "
                     "steps described in the revision history. This usually means that someone has "
                     "made manual changes to the database's DDL, or some model has been changed "
                     "without also generating a migration to describe that change.",

--- a/src/pytest_alembic/tests/experimental/collect_clean_alembic_environment.py
+++ b/src/pytest_alembic/tests/experimental/collect_clean_alembic_environment.py
@@ -2,7 +2,7 @@
 
 This module is executed within a subprocess in order to maintain a clean
 python import state. Thus the `print` statements are the mechanism through
-through which this script communicates the environment state back to the
+which this script communicates the environment state back to the
 parent process.
 """
 import gc


### PR DESCRIPTION
First of all, a great project. Helped me a lot in testing my pet projects!

I wanted to make a small contribution, and fix the typos I noticed.