### PR TITLE
fix: Correctly insert the root package during metaadata detection.

### DIFF
--- a/examples/test_experimental_all_models_register_namespace_package/alembic.ini
+++ b/examples/test_experimental_all_models_register_namespace_package/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/examples/test_experimental_all_models_register_namespace_package/foo/bar/__init__.py
+++ b/examples/test_experimental_all_models_register_namespace_package/foo/bar/__init__.py
@@ -1,0 +1,17 @@
+import sqlalchemy
+from sqlalchemy import Column, types
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class CreatedAt(Base):
+    __tablename__ = "foo"
+
+    id = Column(types.Integer(), autoincrement=True, primary_key=True)
+
+    created_at = sqlalchemy.Column(
+        sqlalchemy.types.DateTime(timezone=True),
+        server_default=sqlalchemy.text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )

--- a/examples/test_experimental_all_models_register_namespace_package/migrations/env.py
+++ b/examples/test_experimental_all_models_register_namespace_package/migrations/env.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(os.path.abspath("."))
+from foo.bar import Base  # isort: skip
+
+
+fileConfig(context.config.config_file_name)
+target_metadata = Base.metadata
+
+
+connectable = context.config.attributes.get("connection", None)
+
+if connectable is None:
+    connectable = engine_from_config(
+        context.config.get_section(context.config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+with connectable.connect() as connection:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()

--- a/examples/test_experimental_all_models_register_namespace_package/migrations/script.py.mako
+++ b/examples/test_experimental_all_models_register_namespace_package/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/examples/test_experimental_all_models_register_namespace_package/migrations/versions/aaaaaaaaaaaa_create_foo.py
+++ b/examples/test_experimental_all_models_register_namespace_package/migrations/versions/aaaaaaaaaaaa_create_foo.py
@@ -1,0 +1,25 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "aaaaaaaaaaaa"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "foo",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("foo")

--- a/examples/test_experimental_all_models_register_namespace_package/migrations/versions/bbbbbbbbbbbb_update_foo.py
+++ b/examples/test_experimental_all_models_register_namespace_package/migrations/versions/bbbbbbbbbbbb_update_foo.py
@@ -1,0 +1,16 @@
+from alembic import op
+
+revision = "bbbbbbbbbbbb"
+down_revision = "aaaaaaaaaaaa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    result = conn.execute("SELECT * FROM foo").fetchall()
+    assert len(result) == 0
+
+
+def downgrade():
+    pass

--- a/examples/test_experimental_all_models_register_namespace_package/pyproject.toml
+++ b/examples/test_experimental_all_models_register_namespace_package/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pytest_alembic_include_experimental = 'all_models_register_on_metadata'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.8.3"
+version = "0.8.4"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py
+++ b/src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py
@@ -219,6 +219,8 @@ def traverse_modules(
         if not hasattr(package, "__path__"):
             return
 
+        yield package
+
         package_path = package.__path__
         for _, name, is_package in walk_packages(package_path):
             full_name = f"{package.__name__}.{name}"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -244,3 +244,9 @@ def test_experimental_all_models_register_async(pytester):
 def test_experimental_all_models_register_offline(pytester):
     """Assert all_models_register_on_metadata runs with offline param."""
     run_pytest(pytester, passed=1, test_alembic=False)
+
+
+def test_experimental_all_models_register_namespace_package(pytester):
+    """Assert all_models_register_on_metadata with namespace packages."""
+    pytester.syspathinsert(pytester.path)
+    run_pytest(pytester, passed=5)

--- a/tests/tests/experimental/test_all_models_register_on_metadata.py
+++ b/tests/tests/experimental/test_all_models_register_on_metadata.py
@@ -64,11 +64,10 @@ class Test_traverse_modules:
         result = list(
             traverse_modules("asdf", import_module=import_module, walk_packages=walk_packages)
         )
-        assert result == [child]
+        assert result == [module, child]
 
     def test_package_child_import_error(self):
         module = make_module("name", package="name", path="name")
-        # child = make_module("child", package="name.child", path="name")
         import_module = yield_per_call(module, ImportError("name.child"))
 
         walk_packages = yield_per_call([(None, "child", False)], [])
@@ -76,7 +75,7 @@ class Test_traverse_modules:
         result = list(
             traverse_modules("asdf", import_module=import_module, walk_packages=walk_packages)
         )
-        assert result == []
+        assert result == [module]
 
     def test_package_child_is_package(self):
         module = make_module("name", package="name", path="name")
@@ -89,7 +88,7 @@ class Test_traverse_modules:
         result = list(
             traverse_modules("asdf", import_module=import_module, walk_packages=walk_packages)
         )
-        assert result == [child]
+        assert result == [module, child]
 
 
 class Test_get_full_tableset:


### PR DESCRIPTION
We were previously failing to include the root package during metadata detection. Meaning if the root `package/__init__.py` included the metadata, we would fail to notice it.