### PR TITLE
Update Python version used on readthedocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,6 +9,6 @@ build:
 formats: all
 
 python:
-  version: 3.6
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Python 3.6 is EOL and causes issues (lack of dataclasses breaks sphinx.ext.autodoc).

I'm not sure what version is appropriate.  ReadTheDocs themselves seem to have [defaulted to Python 3.8](https://github.com/readthedocs/readthedocs.org/pull/7421), so that's what I went with.

Fixes #66.  (I forgot to include this bit in the commit message, sorry!)