### PR TITLE
fix: Ensure parity of behavior between testing with/without `--test-alembic`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ test:
 	coverage xml
 
 lint:
-	flake8 src tests
-	isort --check-only src tests
-	pydocstyle src tests
-	black --check src tests
-	mypy src tests
-	bandit -r src
+	flake8 src tests || exit 1
+	isort --check-only src tests || exit 1
+	pydocstyle src tests || exit 1
+	black --check src tests || exit 1
+	mypy src tests || exit 1
+	bandit -r src --skip B101 || exit 11
 
 format:
 	isort src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.10.1"
+version = "0.10.2"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/src/pytest_alembic/plugin/error.py
+++ b/src/pytest_alembic/plugin/error.py
@@ -1,33 +1,25 @@
 import textwrap
-
-from _pytest._code.code import FormattedExcinfo
+from typing import List
 
 
 class AlembicTestFailure(AssertionError):
     def __init__(self, message, context=None):
         super().__init__(message)
         self.context = context
+        self.exce = self
+        self.item = None
 
-
-class AlembicReprError:
-    def __init__(self, exce, item):
-        self.exce = exce
-        self.item = item
-
-    def toterminal(self, tw):
+    def format_context(self) -> List[str]:
         """Print out a custom error message to the terminal."""
-        exc = self.exce.value
-        context = exc.context
+        result = []
+        if not self.context:
+            return []
 
-        if context:
-            for title, item in context:
-                tw.line(title + ":", white=True, bold=True)
-                tw.line(textwrap.indent(item, "    "), red=True)
-                tw.line("")
+        for title, item in self.context:
+            result.extend(["", f"{title}:", textwrap.indent(item, "    ")])
+        return result
 
-        e = FormattedExcinfo()
-        lines = e.get_exconly(self.exce)
-
-        tw.line("Errors:", white=True, bold=True)
-        for line in lines:
-            tw.line(line, red=True, bold=True)
+    def __str__(self):
+        content = self.format_context()
+        segments = [super().__str__(), *content]
+        return "\n".join(segments)

--- a/src/pytest_alembic/plugin/hooks.py
+++ b/src/pytest_alembic/plugin/hooks.py
@@ -11,6 +11,11 @@ def pytest_addoption(parser):
     experimental_tests = ", ".join(t.name for t in experimental_collector.available_tests.values())
 
     parser.addini(
+        "pytest_alembic_enabled",
+        "Whether to enable/disable the plugin's behavior entirely. Defaults to true.",
+        default=True,
+    )
+    parser.addini(
         "pytest_alembic_include",
         "List of built-in tests to include. If specified, 'pytest_alembic_exclude' is ignored. "
         f"If both are omitted, all tests are included. Valid options include: {default_tests}",
@@ -40,7 +45,7 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Enable pytest-alembic built-in tests",
-        dest="pytest_alembic_enabled",
+        dest="pytest_alembic_registration_enabled",
     )
     group.addoption(
         "--alembic-exclude",
@@ -61,6 +66,6 @@ def pytest_configure(config):
 
 
 def pytest_sessionstart(session):
-    if session.config.option.pytest_alembic_enabled:
+    if session.config.getini("pytest_alembic_enabled"):
         plugin = PytestAlembicPlugin(session.config)
         session.config.pluginmanager.register(plugin, "pytest-alembic")

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -6,8 +6,6 @@ from typing import Callable, Dict, List, Optional
 import pytest
 from _pytest import config
 
-from pytest_alembic.plugin.error import AlembicReprError, AlembicTestFailure
-
 pytest_version_tuple = getattr(pytest, "version_tuple", None)
 
 
@@ -60,11 +58,12 @@ class TestCollector(pytest.Module):
         self.add_marker("alembic")
 
     def collect(self):
+        assert self.parent
         config = self.parent.config
 
-        cli_enabled = config.option.pytest_alembic_enabled
+        cli_enabled = config.option.pytest_alembic_registration_enabled
         if not cli_enabled:
-            return None
+            return []
 
         option = config.option
 
@@ -100,11 +99,6 @@ class TestCollector(pytest.Module):
 class PytestAlembicItem(pytest.Function):
     def reportinfo(self):
         return (self.fspath, 0, f"[pytest-alembic] {self.name}")
-
-    def repr_failure(self, excinfo):
-        if isinstance(excinfo.value, AlembicTestFailure):
-            return AlembicReprError(excinfo, self)
-        return super().repr_failure(excinfo)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixes https://github.com/schireson/pytest-alembic/issues/79