### PR TITLE
fix: Avoid unnecessary commit during run_task.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.10.7"
+version = "0.10.8"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -11,5 +11,6 @@ pg = create_postgres_fixture(metadata)
 
 
 def test_table_insert(pg):
-    command_executor = ConnectionExecutor(pg)
-    command_executor.table_insert("", [{"name": "who"}], tablename="t")
+    with pg.begin() as conn:
+        command_executor = ConnectionExecutor(conn)
+        command_executor.table_insert("", [{"name": "who"}], tablename="t")


### PR DESCRIPTION
Adding support for sqlalchemy 2.0 swapped a `connect()` call to a `begin()` call, which seems to be unnecessary

Fixes https://github.com/schireson/pytest-alembic/issues/91