### PR TITLE
fix: fixture definition incompatibility with 8.x.x series pytest.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,22 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        pytest-version: ["6.2.0", "7.0.0"]
-        pytest-asyncio-version: ["0.16.0", "0.19.0"]
+        pytest-version: ["6.2.0", "7.0.0", "8.1.0"]
+        pytest-asyncio-version: ["0.16.0", "0.23.0"]
         sqlalchemy-version: ["1.3.0", "1.4.0", "2.0.0"]
+
+        exclude:
+          # old versions of pytest-asyncio use old pytest hook syntax
+        - pytest-version: "8.1.0"
+          pytest-asyncio-version: "0.16.0"
+
+          # new pytest versions are only 3.8 compatible
+        - pytest-version: "8.1.0"
+          python-version: "3.7"
+
+          # new pytest-asyncio versions are only 3.8 compatible
+        - pytest-asyncio-version: "0.23.0"
+          python-version: "3.7"
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-alembic"
-version = "0.10.7"
+version = "0.11.0"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [
     "Dan Cardin <ddcardin@gmail.com>",

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -16,9 +16,16 @@ class PytestAlembicPlugin:
 
     # Some weird decisions were made by pytest it seems like. There is not an obvious
     # way to support both <7 and >=7 without weird nonsense like this.
-    if pytest_version_tuple and pytest_version_tuple[0] >= 7:
+    if pytest_version_tuple and pytest_version_tuple >= (8, 1, 0):
 
-        def pytest_collect_file(self, file_path, path, parent):  # noqa: ARG002
+        def pytest_collect_file(self, file_path, parent):
+            if self.should_register(file_path):
+                return TestCollector.from_parent(parent, path=file_path)
+            return None
+
+    elif pytest_version_tuple and pytest_version_tuple[0] >= 7:
+
+        def pytest_collect_file(self, file_path, path, parent):  # type: ignore[misc] # noqa: ARG002
             if self.should_register(file_path):
                 return TestCollector.from_parent(parent, path=file_path)
             return None


### PR DESCRIPTION
Fixes https://github.com/schireson/pytest-alembic/issues/100

Seems like the way pytest has done this series of deprecatations, there's no "correct" way to support v6 and v7 and v8 without just redefining the function according to the different shapes...sigh