### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         pytest-version: ["7.0.0", "8.3.5"]
         pytest-asyncio-version: ["0.16.0", "0.23.0"]
-        sqlalchemy-version: ["1.4.0", "2.0.40"]
+        sqlalchemy-version: ["2.0.40"]
 
         exclude:
           # old versions of pytest-asyncio use old pytest hook syntax

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         pytest-version: ["7.0.0", "8.3.5"]
         pytest-asyncio-version: ["0.16.0", "0.23.0"]
         sqlalchemy-version: ["1.4.0", "2.0.40"]

--- a/src/pytest_alembic/executor.py
+++ b/src/pytest_alembic/executor.py
@@ -182,7 +182,11 @@ class ConnectionExecutor:
             return asyncio.run(run(self.connection))
 
         if isinstance(self.connection, Engine):
-            with self.connection.begin() as connection:
-                return fn(connection=connection, **kwargs)
+            connection = self.connection.connect()
+            result = fn(connection=connection, **kwargs)
+            connection.commit()
+            # SQLite does not close via the context manager, close expliclitly
+            connection.close()
+            return result
 
         return fn(connection=self.connection, **kwargs)

--- a/src/pytest_alembic/executor.py
+++ b/src/pytest_alembic/executor.py
@@ -182,9 +182,9 @@ class ConnectionExecutor:
             return asyncio.run(run(self.connection))
 
         if isinstance(self.connection, Engine):
-            connection = self.connection.connect()
-            result = fn(connection=connection, **kwargs)
-            connection.commit()
+            with self.connection.begin() as connection:
+                result = fn(connection=connection, **kwargs)
+
             # SQLite does not close via the context manager, close expliclitly
             connection.close()
             return result

--- a/src/pytest_alembic/plugin/fixtures.py
+++ b/src/pytest_alembic/plugin/fixtures.py
@@ -122,4 +122,8 @@ def alembic_config() -> Union[Dict[str, Any], alembic.config.Config, Config]:
 @pytest.fixture()
 def alembic_engine():
     """Override this fixture to provide pytest-alembic powered tests with a database handle."""
-    return sqlalchemy.create_engine("sqlite:///")
+    engine = sqlalchemy.create_engine("sqlite:///")
+    try:
+        yield engine
+    finally:
+        engine.dispose()


### PR DESCRIPTION
SQLite connection needs to be explicitly closed: https://docs.python.org/3/library/sqlite3.html#how-to-use-the-connection-context-manager

Fixes #127 