### PR TITLE
feat: add type hints to exposed tests

### DIFF
--- a/src/pytest_alembic/tests/default.py
+++ b/src/pytest_alembic/tests/default.py
@@ -6,6 +6,7 @@ from alembic.autogenerate.api import AutogenContext
 from alembic.autogenerate.render import _render_cmd_body
 
 from pytest_alembic.plugin.error import AlembicTestFailure
+from pytest_alembic.runner import MigrationContext
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ NOT_IMPLEMENTED_WARNING = (
 
 
 @pytest.mark.alembic
-def test_single_head_revision(alembic_runner):
+def test_single_head_revision(alembic_runner: MigrationContext) -> None:
     """Assert that there only exists one head revision.
 
     We're not sure what realistic scenario involves a diverging history to be desirable. We
@@ -39,7 +40,7 @@ def test_single_head_revision(alembic_runner):
 
 
 @pytest.mark.alembic
-def test_upgrade(alembic_runner):
+def test_upgrade(alembic_runner: MigrationContext) -> None:
     """Assert that the revision history can be run through from base to head."""
     try:
         alembic_runner.migrate_up_to("heads", return_current=False)
@@ -55,7 +56,7 @@ def test_upgrade(alembic_runner):
 
 
 @pytest.mark.alembic
-def test_model_definitions_match_ddl(alembic_runner):
+def test_model_definitions_match_ddl(alembic_runner: MigrationContext) -> None:
     """Assert that the state of the migrations matches the state of the models describing the DDL.
 
     In general, the set of migrations in the history should coalesce into DDL which is described
@@ -99,7 +100,7 @@ def test_model_definitions_match_ddl(alembic_runner):
 
 
 @pytest.mark.alembic
-def test_up_down_consistency(alembic_runner):
+def test_up_down_consistency(alembic_runner: MigrationContext) -> None:
     """Assert that all downgrades succeed.
 
     While downgrading may not be lossless operation data-wise, there's a theory of database

--- a/src/pytest_alembic/tests/default.py
+++ b/src/pytest_alembic/tests/default.py
@@ -30,12 +30,12 @@ def test_single_head_revision(alembic_runner: MigrationContext) -> None:
     head_count = len(heads)
 
     if head_count != 1:
-        heads = "\n".join([h.strip() for h in heads])
+        heads_str = "\n".join([h.strip() for h in heads])
 
         message = f"Expected 1 head revision, found {head_count}"
         raise AlembicTestFailure(
             message,
-            context=[("Heads", heads)],
+            context=[("Heads", heads_str)],
         )
 
 

--- a/tests/tests/experimental/test_collect_clean_alembic_environment.py
+++ b/tests/tests/experimental/test_collect_clean_alembic_environment.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Any, ClassVar, Optional
 
 import pytest
 from sqlalchemy import MetaData
@@ -21,12 +21,12 @@ from pytest_alembic.tests.experimental.collect_clean_alembic_environment import 
 
 
 class MigrationContext:
-    def __init__(self, target_metdata):
+    def __init__(self, target_metdata: Any) -> None:
         self.opts = {"target_metadata": target_metdata}
 
 
 class Test_environment_context_fn:
-    def test_no_target_metadata(self, capsys):
+    def test_no_target_metadata(self, capsys: pytest.CaptureFixture[str]) -> None:
         context = MigrationContext(target_metdata=None)
         environment_context_fn(None, context)
         output = capsys.readouterr().out
@@ -37,7 +37,7 @@ class Test_environment_context_fn:
             "tables": [],
         }
 
-    def test_output(self, capsys):
+    def test_output(self, capsys: pytest.CaptureFixture[str]) -> None:
         class Target:
             tables: ClassVar[dict] = {"t1": None}
 
@@ -53,13 +53,13 @@ class Test_environment_context_fn:
 
 
 class Test_identify_modules:
-    def test_has_model_base_metadata(self):
+    def test_has_model_base_metadata(self) -> None:
         metadata = MetaData()
         declarative_base(metadata=metadata)
         modules = list(identify_modules(metadata))
         assert modules == []
 
-    def test_has_model_base(self):
+    def test_has_model_base(self) -> None:
         Base = declarative_base()
         modules = list(identify_modules(Base))
         assert modules == []
@@ -67,14 +67,14 @@ class Test_identify_modules:
     metadata = MetaData()
     _refers_to_metadata: ClassVar = [metadata]
 
-    def test_just_metadata(self):
+    def test_just_metadata(self) -> None:
         modules = list(identify_modules(self.metadata))
         assert modules == []
 
 
 @dataclass
 class Loader:
-    name: str
+    name: Optional[str]
 
 
 class Test_get_referrer_module:
@@ -87,7 +87,7 @@ class Test_get_referrer_module:
             ("meow", ["meow"]),
         ],
     )
-    def test_get_referer(self, name, loader_name):
+    def test_get_referer(self, name: Optional[str], loader_name: list) -> None:
         referrer = {"__loader__": Loader(name)}
         actual_loader_name = list(get_referrer_module(referrer))
         assert actual_loader_name == loader_name


### PR DESCRIPTION
This PR adds type coverage to tests that are part of the public interface. This avoids issues in usage when strict mode is enabled in pyright and other tools