### PR TITLE
docs: Correct contributing guide toolchain, add make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,35 @@
-.PHONY: install build test lint format publish
+.PHONY: help install build test lint format publish changelog
 .DEFAULT_GOAL := test
 
-install:
+help:  ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+install:  ## Install the package and its dev dependencies
 	uv sync
 
-build:
+build:  ## Build the sdist and wheel
 	uv build
 
-test:
+test:  ## Run the test suite with coverage reports
 	SQLALCHEMY_WARN_20=1 COVERAGE_PROCESS_START="$(PWD)/pyproject.toml" \
 	uv run coverage run -m pytest src tests -vv
 	uv run coverage combine
 	uv run coverage report -i
 	uv run coverage xml
 
-lint:
+lint:  ## Check lint, formatting and types (ruff, mypy)
 	uv run ruff check src tests examples || exit 1
 	uv run ruff format --check src tests examples || exit 1
 	uv run mypy src tests || exit 1
 
-format:
+format:  ## Apply ruff fixes and formatting in place
 	uv run ruff check --fix src tests examples
 	uv run ruff format src tests examples
 
-publish: build
+publish: build  ## Build and publish to PyPI
 	uv publish --token '${PYPI_TOKEN}'
 
-changelog:
+changelog:  ## Regenerate CHANGELOG.md via convco
 	# https://convco.github.io/
 	convco changelog > CHANGELOG.md

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -4,20 +4,23 @@ Contributing
 Prerequisites
 -------------
 
-If you are not already familiar with Poetry_, this is a poetry project, so you'll need this!
+This project is managed with uv_, so you'll need that first. See the `uv installation
+docs`_ for the available options.
+
+The test suite provisions a real postgres instance through pytest-mock-resources_, so
+you will also need Docker running locally.
 
 Getting Setup
 -------------
-Note, while the project itself provisionally runs on Python 3.8, test dependencies
-including pytest-mock-resources, coverage, and black, have minimum python versions of 3.9.
-So local development of pytest-alembic itself requires. Additionally this means
-we dont test 3.8 support, so supporting it is best effort until it becomes inconvenient.
+``pytest-alembic`` supports Python 3.9 and above (see ``requires-python`` in
+``pyproject.toml``). CI exercises 3.9 through 3.13 against a matrix of ``pytest``,
+``pytest-asyncio`` and ``sqlalchemy`` versions.
 
-See the :code:`Makefile` for common commands, but for some basic setup:
+Run :code:`make help` to list the common commands, but for some basic setup:
 
 .. code-block:: bash
 
-    # Installs the package with all the extras
+    # Installs the package along with its dev dependencies
     make install
 
 And you'll want to make sure you can run the tests and linters successfully:
@@ -25,12 +28,33 @@ And you'll want to make sure you can run the tests and linters successfully:
 .. code-block:: bash
 
     # Runs CI-level tests, with coverage reports
-    make test lint
+    make test
 
+    # Runs ruff (lint and format check) and mypy
+    make lint
+
+Both of these are the same entry points CI uses, so a green :code:`make test lint`
+locally should mean a green build.
+
+If :code:`make lint` reports formatting differences or fixable lint errors,
+:code:`make format` applies them in place.
+
+Building the docs
+-----------------
+
+The docs dependencies live in a non-default group, so :code:`make install` does not
+include them:
+
+.. code-block:: bash
+
+    uv sync --group docs
+    uv run sphinx-autobuild docs/source docs/build
 
 Need help
 ---------
 
 Submit an issue!
 
-.. _Poetry: https://poetry.eustace.io/
+.. _uv: https://docs.astral.sh/uv/
+.. _uv installation docs: https://docs.astral.sh/uv/getting-started/installation/
+.. _pytest-mock-resources: https://github.com/schireson/pytest-mock-resources


### PR DESCRIPTION
Closes #152.

`docs/source/contributing.rst` is the documented way into this project, and it named the wrong toolchain throughout. The repo moved to `uv` in c29fb50 ("refactor: Adopt uv") and lints with `ruff`, but the guide still told a new contributor this was a Poetry project using `black`, on Python 3.8.

## Changes

**`docs/source/contributing.rst`**

| Was | Now |
| --- | --- |
| "this is a poetry project", linking `poetry.eustace.io` | managed with `uv`, linking the uv installation docs |
| test deps "including … black" | `make lint` runs ruff (lint + format check) and mypy, with `make format` to apply fixes |
| "provisionally runs on Python 3.8 … best effort" | Python 3.9+, per `requires-python`; notes the 3.9–3.13 CI matrix |
| "See the `Makefile` for common commands" | `make help` lists them |
| `make install` "with all the extras" | installs the package and its **dev** dependencies |

Two additions beyond the issue, both verified rather than assumed:

- **Docker is now documented as a prerequisite.** `tests/conftest.py:1` uses `create_postgres_fixture`, and the `examples/` tree does so throughout, so the suite provisions real postgres through pytest-mock-resources. This was undocumented and is the most likely reason a newcomer's first `make test` fails.
- **A "Building the docs" section.** `uv sync` installs the `dev` group but not `docs` (confirmed: no sphinx in the venv after `make install`), so building docs needs `uv sync --group docs` explicitly.

**`Makefile`** — added a `help` target and `## ` descriptions to all eight targets, so the guide's `make help` reference resolves rather than sending contributors to read the Makefile source. `.DEFAULT_GOAL := test` is unchanged; no recipe was modified.

## Verification

- `make help` renders all eight targets.
- `uv run sphinx-build -W --keep-going -b html docs/source …` writes `contributing` with zero warnings. (The build reports 2 pre-existing warnings in `experimental_tests.rst` from toml-lexing a mixed toml/ini block — untouched here, and Read the Docs does not build with `-W`.)
- `make lint` passes: ruff clean, 251 files formatted, mypy clean on 30 source files.

Docs-only plus a Makefile `help` target; no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
