### PR TITLE
ci: Gate PyPI publishing on a green test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,22 @@
 name: CI
 on:
+  # Branches only. Tag pushes reach this workflow through release.yml, which
+  # calls it via workflow_call so that publishing waits on a green matrix; a
+  # bare `push:` would additionally run the matrix a second time on the tag.
   push:
+    branches:
+      - "**"
   pull_request:
+  workflow_call:
+    inputs:
+      working-directory:
+        # Already referenced by the Coveralls flag name below. Declared with an
+        # empty default so the reference stays valid now that this workflow has
+        # a real input schema, and resolves to the same value it always did.
+        description: Optional label fragment for the Coveralls flag name.
+        type: string
+        required: false
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,17 @@ on:
       - "v*.*.*"
 
 jobs:
+  # Run the full CI matrix for the tagged commit before anything is published.
+  # `needs: test` below is what makes this a gate: a tag pushed onto a commit
+  # whose tests fail stops here, having released nothing.
+  #
+  # No `secrets: inherit` — the called workflow only uses GITHUB_TOKEN, which is
+  # provided automatically, so PYPI_TOKEN stays scoped to the publish job.
+  test:
+    uses: ./.github/workflows/build.yml
+
   gh-release:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,6 +27,7 @@ jobs:
           generate_release_notes: true
 
   publish-pypi:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,4 +40,4 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           uv build
-          uv publish --token $PYPI_TOKEN
+          uv publish --token "$PYPI_TOKEN"


### PR DESCRIPTION
Closes #151.

`release.yml` triggered on any `v*.*.*` tag and ran `uv build && uv publish` with **no dependency on CI**. The test matrix lives in a separate workflow (`build.yml`), so on a tag push both started at once and the publish did not wait — a tag on a commit whose build was failing, or merely still running, shipped to PyPI anyway. Every downstream user gets that release.

## The fix

`build.yml` gains `workflow_call`, and `release.yml` runs it as a `test` job that both `gh-release` and `publish-pypi` declare `needs:` on:

```yaml
jobs:
  test:
    uses: ./.github/workflows/build.yml

  gh-release:
    needs: test
    ...
  publish-pypi:
    needs: test
```

Ordering is now guaranteed by Actions rather than by timing, and a red matrix stops the tag having published nothing.

I chose this over the two alternatives in the issue deliberately:

- **A `workflow_run` trigger** would work, but the guard is subtle — `github.ref` becomes the default branch, so the tag has to be recovered from `head_branch` and passed to the release action by hand. Getting that wrong publishes on *every* successful CI run on `main`, which is a worse failure than the one being fixed.
- **A gate job polling the Checks API** cannot avoid the race: the tag push starts both workflows simultaneously, so the gate would have to poll for a run that has not necessarily appeared yet, with a timeout to guess at.

Reusing the workflow needs no event plumbing and no polling.

### Two supporting details

**`push:` narrowed to branches** in `build.yml`. Tag pushes now reach it through `release.yml`; leaving a bare `push:` would run the whole 5×2×2 matrix a second time on every tag.

**No `secrets: inherit` on the call.** `build.yml` only uses `GITHUB_TOKEN`, which reusable workflows receive automatically, so `PYPI_TOKEN` stays scoped to the publish job instead of being handed to the test matrix.

## Two incidental fixes, both pre-existing

Both are things `actionlint` already reports against `main`:

- **`inputs.working-directory` is declared.** The Coveralls flag name referenced it while nothing defined it — `property "working-directory" is not defined in object type {}` on `main` today. Left undeclared next to a real `workflow_call` input schema, that risked becoming a hard *invalid workflow file* error and taking all of CI with it. The empty default preserves the value it always resolved to, so the flag name is unchanged.
- **`$PYPI_TOKEN` is quoted** in the publish step (SC2086).

## Verification

`actionlint` v1.7.7 on both workflows: **no findings**, where `main` reports two.

```
$ actionlint .github/workflows/build.yml .github/workflows/release.yml   # this branch
$ echo $?
0
```

No Python changed, so the test suite is untouched by this PR — though `build.yml` running on this very pull request is itself a check that the reusable-workflow refactor is valid.

## Worth a maintainer's eye

`COVERALLS_FLAG_NAME` is now explicitly `run-` for every matrix entry, as it has been all along. Coveralls parallel mode generally wants a *distinct* flag per job, so this may be worth setting from the matrix values the way the artifact name just above it already is. I left it alone as out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
