### PR TITLE
ci: Add vulnerability scanning for Python dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,11 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  # Python dependencies, from pyproject.toml and uv.lock. Covers every group,
+  # so advisories against dev and docs tooling arrive as pull requests rather
+  # than only as a CI finding.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,28 @@ jobs:
           uv pip install tomli coveralls
           uv run coveralls --service=github
 
+  audit:
+    # Dependency vulnerability scan. Deliberately outside the test matrix and
+    # with no `needs:` — the lockfile is identical for every matrix entry, so
+    # auditing it 20 times would report the same answer 20 times.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Audit runtime dependencies
+        run: make audit
+
+      - name: Audit dev and docs dependencies
+        # Informational. The docs group reaches mistune 0.8.4 through m2r2,
+        # which pins it exactly (`mistune==0.8.4`), so its advisories cannot be
+        # resolved without replacing m2r2. Reported rather than gated, so a
+        # dependency this repo cannot move does not permanently redden the build.
+        continue-on-error: true
+        run: make audit-all
+
   finish:
     needs:
       - test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build test lint format publish
+.PHONY: install build test lint format publish audit audit-all
 .DEFAULT_GOAL := test
 
 install:
@@ -22,6 +22,14 @@ lint:
 format:
 	uv run ruff check --fix src tests examples
 	uv run ruff format src tests examples
+
+audit:  ## Audit runtime dependencies for known vulnerabilities
+	uv export --frozen --no-emit-project --no-dev --no-hashes --format requirements-txt \
+		| uvx pip-audit --no-deps -r /dev/stdin
+
+audit-all:  ## Audit every dependency group, including dev and docs
+	uv export --frozen --no-emit-project --all-groups --no-hashes --format requirements-txt \
+		| uvx pip-audit --no-deps -r /dev/stdin
 
 publish: build
 	uv publish --token '${PYPI_TOKEN}'


### PR DESCRIPTION
Closes #154.

Nothing scanned this repo's **Python** dependencies for known advisories. `.github/dependabot.yaml` declared exactly one ecosystem — `github-actions` — so action versions got weekly PRs while `alembic`, `sqlalchemy`, `pytest` and the whole `dev`/`docs` groups, all pinned in a committed `uv.lock`, were never checked against an advisory database. For a package installed into other projects' test environments, an advisory against a transitive dependency surfaced to nobody.

Source-level analysis was already covered — `[tool.ruff.lint]` selects `S` (flake8-bandit) and `make lint` runs it over `src tests examples` — so this is specifically the missing *dependency-audit* half, not a bandit gap.

## What this found

The audit is not hypothetical. The `docs` group currently carries **25 advisories against `mistune 0.8.4`**, reached through `m2r2`:

```
$ make audit-all
Found 25 known vulnerabilities in 1 package
Name    Version ID              Fix Versions
mistune 0.8.4   PYSEC-2026-2652 3.3.0
mistune 0.8.4   PYSEC-2026-2218 3.3.0
...
```

**It cannot be fixed by bumping.** `m2r2==0.3.4` declares `mistune==0.8.4` as an exact pin (`requires_dist: ['mistune==0.8.4', 'docutils>=0.19']`), and `uv lock --upgrade-package mistune` leaves it at 0.8.4. Resolving these means replacing `m2r2` — `myst-parser` is the usual modern substitute — which is a docs-toolchain decision well beyond this issue, so I've left it alone and surfaced it instead.

## Two mechanisms, scoped differently

| | Scope | In CI |
| --- | --- | --- |
| `make audit` | runtime only (`--no-dev`) — what downstream users install | **gates** the build |
| `make audit-all` | every group, incl. dev and docs | reported, `continue-on-error` |
| Dependabot `uv` | `pyproject.toml` + `uv.lock`, all groups | weekly PRs |

The split is the point. Gating on the full set would redden the build permanently over a pin this repo cannot move, which trains people to ignore it. Gating on what actually ships is clean today, so it starts green and a regression there means something. The dev/docs findings still get a route to a human — Dependabot PRs, plus a visible non-blocking CI step.

The `audit` job sits outside the test matrix with no `needs:`, since the lockfile is identical for every matrix entry and auditing it 20 times would report the same answer 20 times.

## Verification

- `make audit` → `No known vulnerabilities found`, exit **0**.
- `make audit-all` → 25 findings, exit **1** (hence `continue-on-error`).
- `package-ecosystem: "uv"` checked against the official Dependabot schema (`json.schemastore.org/dependabot-2.0.json`) — `uv` is in the ecosystem enum, alongside `pip`.
- `actionlint` reports nothing against the new `audit` job.

## Note for the maintainer

This branch is cut from `main`, like my other open PRs, so they can merge in any order — but two of them touch files this one also touches:

- **`Makefile`** — also rewritten by #155 (adds a `help` target and `##` descriptions). I wrote the new targets with `##` descriptions so they slot into that convention; resolution is "keep both".
- **`.github/workflows/build.yml`** — also changed by #157 (adds `workflow_call`). Different region of the file (`on:` vs `jobs:`), so it should merge cleanly.

`actionlint` still reports the pre-existing `inputs.working-directory` error on this branch. That's #157's fix; I deliberately didn't duplicate it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
