### PR TITLE
fix: Honour the `default` argument of collect_test_definitions

### DIFF
--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -133,13 +133,15 @@ class OptionResolver:
     def collect_test_definitions(
         cls,
         *,
-        default=True,  # noqa: ARG003
+        default=True,
         experimental=True,
     ):
         import pytest_alembic.tests
         import pytest_alembic.tests.experimental
 
-        test_groups = [(pytest_alembic.tests, False)]
+        test_groups = []
+        if default:
+            test_groups.append((pytest_alembic.tests, False))
         if experimental:
             test_groups.append((pytest_alembic.tests.experimental, True))
 

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -17,6 +17,46 @@ def test_parse_raw_test_names_empty_skips():
     assert expected_result == result
 
 
+class Test__collect_test_definitions:
+    def test_default_only(self):
+        collector = OptionResolver.collect_test_definitions(default=True, experimental=False)
+
+        assert sorted(collector.available_tests) == [
+            "model_definitions_match_ddl",
+            "single_head_revision",
+            "up_down_consistency",
+            "upgrade",
+        ]
+
+    def test_experimental_only(self):
+        # `default=False` must actually exclude the default group. `pytest_addoption`
+        # relies on this to describe `pytest_alembic_include_experimental`, so a
+        # regression here silently advertises non-experimental tests as experimental.
+        collector = OptionResolver.collect_test_definitions(default=False, experimental=True)
+
+        assert sorted(collector.available_tests) == [
+            "all_models_register_on_metadata",
+            "downgrade_leaves_no_trace",
+        ]
+
+    def test_both_groups(self):
+        collector = OptionResolver.collect_test_definitions(default=True, experimental=True)
+
+        assert sorted(collector.available_tests) == [
+            "all_models_register_on_metadata",
+            "downgrade_leaves_no_trace",
+            "model_definitions_match_ddl",
+            "single_head_revision",
+            "up_down_consistency",
+            "upgrade",
+        ]
+
+    def test_neither_group(self):
+        collector = OptionResolver.collect_test_definitions(default=False, experimental=False)
+
+        assert collector.available_tests == {}
+
+
 class Test__OptionResolver:
     def test_all_enabled(self):
         test_collector = OptionResolver.collect_test_definitions()


### PR DESCRIPTION
Closes #164.

## The bug

`OptionResolver.collect_test_definitions` accepted a `default` keyword argument that it
never read. `test_groups` was seeded unconditionally, and the resulting unused-argument
warning was silenced rather than fixed:

```python
        default=True,  # noqa: ARG003
        experimental=True,
    ):
        ...
        test_groups = [(pytest_alembic.tests, False)]
        if experimental:
            test_groups.append((pytest_alembic.tests.experimental, True))
```

`pytest_addoption` relies on that argument (`plugin/hooks.py:8-10`) to build the list of
valid options for the `pytest_alembic_include_experimental` ini setting:

```python
    experimental_collector = OptionResolver.collect_test_definitions(
        default=False, experimental=True
    )
```

Because `default=False` did nothing, that collector returned all six built-in tests, so
the ini help advertised the four **non**-experimental tests as valid experimental options.

Before:

```
experimental help  : all_models_register_on_metadata, downgrade_leaves_no_trace,
                     model_definitions_match_ddl, single_head_revision,
                     up_down_consistency, upgrade
```

After:

```
experimental help  : all_models_register_on_metadata, downgrade_leaves_no_trace
```

## The change

- Build `test_groups` from both flags rather than seeding it with the default group.
- Drop `# noqa: ARG003`. It was suppressing precisely the rule that would have caught
  this, so removing it keeps the check active for the future.
- Add `Test__collect_test_definitions` covering all four flag combinations, including the
  `default=False, experimental=False` empty case. The `test_experimental_only` case carries
  a comment tying it back to the `pytest_addoption` help text, since that is the
  user-visible symptom a future regression would reintroduce.

## Compatibility

No existing test needed changing. `collect_test_definitions()` with no arguments still
defaults to `default=True, experimental=True`, so `Test__OptionResolver.test_all_enabled`
and `test_include_experimental` are unaffected — `tests()` continues to filter by
`is_experimental` when no explicit include list is given.

The only behavioural change is at the single call site that already passed
`default=False`, which is the one this fixes.

## Verification

- `make lint` — ruff check, ruff format and mypy all clean.
- `make test` — 101 passed (was 97), coverage 95% against the configured 93% floor;
  `plugin/plugin.py` moves from 89% to 90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
