### PR TITLE
build: Declare interrogate config for docstring coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,35 @@ strict_optional = true
 ignore_missing_imports = true
 warn_unused_ignores = true
 incremental = true
+
+[tool.interrogate]
+# Docstring *coverage*, as a ratchet. This deliberately complements ruff rather
+# than duplicating it: `D1` is ignored under [tool.ruff.lint], so no individual
+# symbol is required to carry a docstring, while this floor stops the overall
+# proportion from regressing. Public API first, internals as they are touched.
+#
+# Ratcheted floor, in the same spirit as [tool.coverage.report]. Held just below
+# the 45.0% observed locally so an unrelated refactor that adds an undocumented
+# helper does not redden the build; raise it whenever the measured number moves up.
+fail-under = 44
+
+# Re-export modules (`__init__.py`) hold only imports and `__all__`; magic
+# methods and nested helpers are not a documentation surface. `ignore-init-method`
+# is intentionally absent: it is mutually exclusive with `style = "google"`, where
+# the class docstring is what documents `__init__`.
+ignore-init-module = true
+ignore-magic = true
+ignore-nested-functions = true
+ignore-private = true
+ignore-semiprivate = true
+
+# Note: ignore-property-decorators / ignore-setters / ignore-overloaded-functions
+# are deliberately left off — this project's properties *are* documented, so
+# excluding them would drop them from the numerator and lower the score.
+
+# Honour the google convention already configured in [tool.ruff.lint.pydocstyle].
+style = "google"
+
+exclude = ["tests", "examples", "docs", "build", "dist", ".venv"]
+omit-covered-files = false
+verbose = 1


### PR DESCRIPTION
Refs #170. Declares the configuration only — wiring it into CI is the rest of that issue.

## Why

Docstring coverage is currently the one quality dimension with **no measurement at all**.
`[tool.ruff.lint.pydocstyle]` enforces docstring *style* (google convention), but
`ignore = ["D1"]` means nothing checks whether a docstring *exists*. The documented
proportion of the API can therefore drift downward indefinitely without any gate noticing.

Measured over `src/`, the current state is **45.0%**, and the shape is deliberate rather
than accidental — the user-facing surface is documented and the internal machinery is not:

| Module | Coverage |
| --- | ---: |
| `runner.py` (public `MigrationContext`) | 87% |
| `plugin/fixtures.py` (the fixtures users consume) | 80% |
| `tests/default.py` (the built-in tests) | 80% |
| `revision_data.py` | 78% |
| `config.py` | 40% |
| `executor.py` | 19% |
| `history.py` | 12% |
| `plugin/plugin.py` (collection machinery) | 5% |
| `plugin/hooks.py` (pytest hook entry points) | 0% |

So the goal here is **not** to chase a high percentage. It is to stop the documented
proportion from regressing, and to raise it deliberately.

## The threshold

`fail-under = 44`, a ratchet one point below the 45.0% observed, matching the idiom
already used for `[tool.coverage.report].fail_under` (93 against ~95% observed).

Interrogate's own default is **80%**, which this package does not come close to. Gating at
that number would adopt a standard the code has never held and would simply redden the
build, so it is set from what the package actually measures. The one point of headroom
means an unrelated refactor that adds one undocumented helper does not fail CI.

## Two option choices worth recording

Both were found by measuring rather than assuming, and both are commented in the file so
they are not "helpfully" reverted later:

- **`ignore-init-method` is mutually exclusive with `style = "google"`.** Interrogate
  refuses to run with both set, because under google convention the class docstring is
  what documents `__init__`. The style is kept, since it already matches the ruff
  pydocstyle setting.
- **`ignore-property-decorators`, `ignore-setters` and `ignore-overloaded-functions` are
  deliberately absent.** This package's properties *are* documented, so excluding them
  removes them from the numerator and *lowers* the score — 45.8% → 45.2% when tried.

`exclude` declares the scope, so a bare `uvx interrogate` self-scopes to
`src/pytest_alembic/` instead of sweeping in `tests/` and `examples/`. Keeping the scope in
the config rather than on the command line is what stops a local run and a CI run
disagreeing.

## What this does not do

`interrogate` is not yet in the `dev` group, there is no make target, and no CI step
invokes it — so this is configuration, not yet a gate. #170 tracks the remainder:
lock the tool in `uv.lock`, add a `docs-coverage` target that passes no flags, and invoke
it once per push **outside** the test matrix, for the same reason the existing `audit` job
documents.

## Verification

```
TOTAL   120   66   54   45.0%
RESULT: PASSED (minimum: 44.0%, actual: 45.0%)
```

`make lint` and `make test` are unaffected — no source changes, and the block parses
cleanly under `tomllib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
