### PR TITLE
docs: Point the coverage badge at Coveralls and the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Github Actions Build](https://github.com/schireson/pytest-alembic/actions/workflows/build.yml/badge.svg)
-[![codecov](https://codecov.io/gh/schireson/pytest-alembic/branch/master/graph/badge.svg)](https://codecov.io/gh/schireson/pytest-alembic)
+[![Coverage Status](https://coveralls.io/repos/github/schireson/pytest-alembic/badge.svg?branch=main)](https://coveralls.io/github/schireson/pytest-alembic?branch=main)
 [![Documentation Status](https://readthedocs.org/projects/pytest-alembic/badge/?version=latest)](https://pytest-alembic.readthedocs.io/en/latest/?badge=latest)
 
 See the full documentation [here](https://pytest-alembic.readthedocs.io/en/latest/).


### PR DESCRIPTION
Closes #167.

```diff
-[![codecov](https://codecov.io/gh/schireson/pytest-alembic/branch/master/graph/badge.svg)](https://codecov.io/gh/schireson/pytest-alembic)
+[![Coverage Status](https://coveralls.io/repos/github/schireson/pytest-alembic/badge.svg?branch=main)](https://coveralls.io/github/schireson/pytest-alembic?branch=main)
```

Two independent things were wrong with one line.

**The service.** CI publishes coverage to **Coveralls**, not codecov —
`.github/workflows/build.yml:81-88` runs `uv run coveralls --service=github`, and the
`finish` job at `:117-122` closes the parallel build. There is no codecov step anywhere in
`.github/workflows/`.

**The branch.** The URL requested `branch/master`; the default branch is `main`
(`origin/HEAD -> origin/main`).

## Why this survived so long

The badge was never *broken*, which is exactly the problem. Checking what each service
actually serves right now:

| URL | Serves |
| --- | --- |
| codecov, `branch/master` (what the README had) | **96%** |
| codecov, `branch/main` | 95% |
| coveralls, `?branch=main` | **95%** |
| coveralls, `?branch=master` | `unknown` |

codecov still returns a confident-looking **96%** for a branch that no longer exists,
frozen at whenever it last received an upload. Frozen data that renders as a normal green
badge is worse than a dead link — nothing ever draws attention to it.

Coveralls, by contrast, has live data. Its JSON API:

```json
{"repo_name":"schireson/pytest-alembic","branch":"main",
 "badge_url":"https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_95.svg",
 "calculated_at":"2026-08-24T17:21:21Z",
 "commit_message":"Merge pull request #158 from tschm/ci/dependency-vuln-scanning"}
```

That commit is the current HEAD, and 95% is exactly what `make test` reports locally
against the 93% floor in `pyproject.toml`. The new badge and the test suite now agree.

Note that `?branch=master` on Coveralls returns `unknown` — which independently confirms
the branch half of the finding, not just the service half.

## One thing a reviewer might trip over

The badge image resolves cleanly (`200`, → `coveralls_95.svg`), but the repo **link**
returns `403` to `curl`. That is a Cloudflare challenge (`<title>Just a moment...</title>`),
not a bad URL — the response body still contains `pytest-alembic`, and the JSON API
confirms the repository. A real browser passes the challenge.

## Verification

- New badge URL → `200`, resolves to `coveralls_95.svg`.
- README fences still parse: 3 blocks (bash, python, bash), 0 violations.
- No code touched, so `make test` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
