### PR TITLE
refactor: Break the package-root import cycle in plugin/fixtures.py

### DIFF
--- a/src/pytest_alembic/plugin/fixtures.py
+++ b/src/pytest_alembic/plugin/fixtures.py
@@ -4,8 +4,8 @@ import alembic.config
 import pytest
 import sqlalchemy
 
-import pytest_alembic
 from pytest_alembic.config import Config
+from pytest_alembic.runner import runner
 
 
 def create_alembic_fixture(raw_config=None):
@@ -43,8 +43,8 @@ def create_alembic_fixture(raw_config=None):
     @pytest.fixture
     def alembic_fixture(alembic_engine):
         config = Config.from_raw_config(raw_config)
-        with pytest_alembic.runner(config=config, engine=alembic_engine) as runner:
-            yield runner
+        with runner(config=config, engine=alembic_engine) as migration_context:
+            yield migration_context
 
     return alembic_fixture
 
@@ -62,8 +62,8 @@ def alembic_runner(alembic_config, alembic_engine):
         ...     assert ...
     """
     config = Config.from_raw_config(alembic_config)
-    with pytest_alembic.runner(config=config, engine=alembic_engine) as runner:
-        yield runner
+    with runner(config=config, engine=alembic_engine) as migration_context:
+        yield migration_context
 
 
 @pytest.fixture

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -136,6 +136,20 @@ class OptionResolver:
         default=True,  # noqa: ARG003
         experimental=True,
     ):
+        # Imported here rather than at module scope to contain the blast radius of a
+        # broken alembic. This module is reached from `pytest_alembic.plugin`, the
+        # pytest11 entry point, so it loads during pytest startup for every project
+        # that merely has pytest-alembic installed. The test modules below import
+        # private alembic APIs -- `alembic.autogenerate.render._render_cmd_body` in
+        # tests/default.py -- and an alembic release that moves one would then break
+        # `pytest` itself everywhere, rather than only for people who actually use
+        # these tests.
+        #
+        # Note this placement is *not* required to avoid an import cycle. There is a
+        # cycle in the graph (plugin.plugin -> tests -> plugin.error), but it is
+        # benign: plugin/error.py imports only textwrap and typing, so it never needs
+        # a partially-initialised module. Hoisting these two imports leaves the whole
+        # suite green -- the reason to keep them here is the blast radius above.
         import pytest_alembic.tests
         import pytest_alembic.tests.experimental
 


### PR DESCRIPTION
Closes #166.

## 1. The package-root cycle — fixed

`plugin/fixtures.py` imported its own package root and reached the context manager through
it:

```python
import pytest_alembic
...
with pytest_alembic.runner(config=config, engine=alembic_engine) as runner:
```

while `pytest_alembic/__init__.py:2` imports `create_alembic_fixture` from that very
module. The submodule depended on the package still being initialised, and survived only
because a plain `import` defers attribute lookup until the fixture body runs.

```diff
-import pytest_alembic
 from pytest_alembic.config import Config
+from pytest_alembic.runner import runner
```

That edge now points downward — `plugin` → `runner` → `executor`/`history`/`revision_data`
— with no path back.

### The rename is not cosmetic

A bare `from pytest_alembic.runner import runner` alongside the existing `with ... as
runner` would make `runner` local to the entire function and fail at the call. Confirmed
on a reduced case:

```
UnboundLocalError: cannot access local variable 'runner' where it is not associated with a value
```

So the yielded value is renamed to `migration_context` — which is also what `runner`
actually yields.

## 2. The deferred import — I was wrong, and the comment says something true instead

#166 claimed the function-local import in `collect_test_definitions` was load-bearing, and
that "hoisting either import to module scope creates a genuine cycle". **That was wrong.**
I hoisted both to module scope and tested it:

| Entry point | Hoisted |
| --- | --- |
| `pytest_alembic` | OK |
| `pytest_alembic.plugin` | OK |
| `pytest_alembic.plugin.plugin` | OK |
| `pytest_alembic.plugin.hooks` | OK |
| `pytest_alembic.plugin.error` | OK |
| `pytest_alembic.tests` | OK |
| `pytest_alembic.tests.experimental` | OK |

…plus the full suite, 97 passed. The cycle `plugin.plugin → tests → plugin.error` is real
in the graph but **benign**: `plugin/error.py` imports only `textwrap` and `typing`, so it
never needs a half-built module.

### But there is a real reason to keep it deferred

Looking for why the deferral existed turned up a better rationale than the one I'd
assumed. `pytest_alembic.plugin` is the **`pytest11` entry point**
(`pyproject.toml:16-17`), so it loads at pytest startup for every project that merely has
pytest-alembic installed. And `tests/default.py:6` imports a **private** alembic API:

```python
from alembic.autogenerate.render import _render_cmd_body
```

Hoisted, an alembic release that moves that symbol breaks **`pytest` itself, everywhere**.
Deferred, it breaks only for people actually using these built-in tests.

So the import stays where it is, and the new comment records the blast-radius reason and
explicitly notes that cycle avoidance is *not* why — so the next person doesn't inherit my
wrong explanation. This deviates from #166's stated "done when", which asked for a comment
asserting the cycle rationale; writing that comment would have committed a false claim to
the codebase. I've corrected #166 itself as well.

## Verification

- All 7 package entry points import cleanly.
- `grep '^import pytest_alembic$' src/` → nothing. No module imports the package root.
- Public API unchanged: `['Config', 'MigrationContext', 'create_alembic_fixture', 'runner']`,
  with `pytest_alembic.runner` still resolving to the function.
- `make lint` clean; `make test` 97 passed, coverage 95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
