### PR TITLE
Fix stale README example, document the plugin layer, and gate docstring coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,27 @@ jobs:
         # be reported into a log nobody reads.
         run: make audit-all
 
+  docs-coverage:
+    # Docstring coverage. Outside the test matrix for the same reason the audit job
+    # documents above: the answer is identical for every matrix entry, so running it
+    # 20 times would report the same number 20 times. Unlike `audit`, this one needs
+    # the dev group installed, since interrogate is a declared dependency rather than
+    # a `uvx` download.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Check docstring coverage
+        run: make docs-coverage
+
   finish:
     needs:
       - test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build test lint format audit audit-all publish changelog
+.PHONY: install build test lint format docs-coverage audit audit-all publish changelog
 .DEFAULT_GOAL := test
 
 help:  ## Show this help
@@ -26,6 +26,11 @@ lint:  ## Check lint, formatting and types (ruff, mypy)
 format:  ## Apply ruff fixes and formatting in place
 	uv run ruff check --fix src tests examples
 	uv run ruff format src tests examples
+
+docs-coverage:  ## Check docstring coverage (interrogate)
+	# No flags: every threshold and exclusion lives in [tool.interrogate] in
+	# pyproject.toml, so a local run and CI measure the same thing.
+	uv run interrogate
 
 audit:  ## Audit runtime dependencies for known vulnerabilities
 	uv export --frozen --no-emit-project --no-dev --no-hashes --format requirements-txt \

--- a/README.md
+++ b/README.md
@@ -118,15 +118,25 @@ that you would normally, through the use of the `alembic_runner`
 fixture.
 
 ```python
+from sqlalchemy import text
+
+
 def test_gnarly_migration_xyz123(alembic_engine, alembic_runner):
     # Migrate up to, but not including this new migration
     alembic_runner.migrate_up_before('xyz123')
 
     # Perform some very specific data setup, because this migration is sooooo complex.
     # ...
-    alembic_engine.execute(table.insert(id=1, name='foo'))
+    alembic_runner.insert_into('tablename', dict(id=1, name='foo'))
 
     alembic_runner.migrate_up_one()
+
+    # `alembic_engine` is a plain sqlalchemy engine, for whenever you need to
+    # inspect the result yourself.
+    with alembic_engine.connect() as conn:
+        rows = conn.execute(text('SELECT id FROM tablename')).fetchall()
+
+    assert rows == [(1,)]
 ```
 
 `alembic_runner` has a number of methods designed to make it convenient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "asyncpg",
     "coverage[toml]>=6.4.4",
     "greenlet>=3.0",
+    "interrogate>=1.7",
     "mypy>=1.11",
     "psycopg2-binary",
     "pytest>=8.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,9 +144,9 @@ incremental = true
 # proportion from regressing. Public API first, internals as they are touched.
 #
 # Ratcheted floor, in the same spirit as [tool.coverage.report]. Held just below
-# the 45.0% observed locally so an unrelated refactor that adds an undocumented
+# the 71.7% observed locally so an unrelated refactor that adds an undocumented
 # helper does not redden the build; raise it whenever the measured number moves up.
-fail-under = 44
+fail-under = 70
 
 # Re-export modules (`__init__.py`) hold only imports and `__all__`; magic
 # methods and nested helpers are not a documentation surface. `ignore-init-method`

--- a/src/pytest_alembic/plugin/error.py
+++ b/src/pytest_alembic/plugin/error.py
@@ -1,9 +1,27 @@
+"""The failure type the built-in tests raise, and how its context is rendered."""
+
 import textwrap
 from typing import List
 
 
 class AlembicTestFailure(AssertionError):  # noqa: N818
+    """A built-in test failure, carrying labelled context to print beneath the message.
+
+    Subclasses :class:`AssertionError` so a migration problem reports as an ordinary
+    test failure rather than an error — the distinction pytest draws between "the code
+    under test is wrong" and "the test itself broke".
+
+    The context exists because the useful part of a migration failure is usually a diff
+    or a revision listing, which is unreadable squeezed onto the assertion line.
+    """
+
     def __init__(self, message, context=None):
+        """Build the failure.
+
+        Args:
+            message: The one-line failure message.
+            context: Optional ``(title, body)`` pairs rendered as indented blocks.
+        """
         super().__init__(message)
         self.context = context
         self.exce = self

--- a/src/pytest_alembic/plugin/hooks.py
+++ b/src/pytest_alembic/plugin/hooks.py
@@ -1,7 +1,24 @@
+"""The pytest hook implementations which expose this plugin's options and register it.
+
+Loaded through the ``pytest11`` entry point declared in ``pyproject.toml``, so pytest
+imports this module for every session, whether or not the plugin ends up active.
+"""
+
 from pytest_alembic.plugin.plugin import OptionResolver, PytestAlembicPlugin
 
 
 def pytest_addoption(parser):
+    """Register this plugin's ini options and command-line flags.
+
+    The set of valid test names is not hard-coded: it is collected from
+    :mod:`pytest_alembic.tests` at option-registration time, so ``--help`` always
+    lists the tests this version actually ships. Default and experimental tests are
+    collected separately because they are opted into differently — experimental ones
+    must be named explicitly.
+
+    Args:
+        parser: The pytest parser to register ini values and options against.
+    """
     default_collector = OptionResolver.collect_test_definitions(default=True, experimental=False)
     default_tests = ", ".join(t.name for t in default_collector.available_tests.values())
 
@@ -63,10 +80,26 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    """Register the ``alembic`` marker, so selecting or deselecting these tests works.
+
+    Registration also keeps the marker from tripping ``--strict-markers``.
+
+    Args:
+        config: The pytest config object for the session being configured.
+    """
     config.addinivalue_line("markers", "alembic: Tests which use pytest-alembic.")
 
 
 def pytest_sessionstart(session):
+    """Register the collection plugin, unless it has been disabled entirely.
+
+    ``pytest_alembic_enabled`` is honoured here rather than at collection time so that
+    a disabled plugin adds no hooks at all, instead of adding hooks which decline to
+    collect.
+
+    Args:
+        session: The pytest session being started.
+    """
     if session.config.getini("pytest_alembic_enabled"):
         plugin = PytestAlembicPlugin(session.config)
         session.config.pluginmanager.register(plugin, "pytest-alembic")

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -1,3 +1,11 @@
+"""Collection machinery: how the built-in tests become pytest items.
+
+The built-in tests are plain functions in :mod:`pytest_alembic.tests`, not files pytest
+would find on its own. They are bound to a single path — ``tests/conftest.py`` by
+default — chosen because that is where users define ``alembic_engine``, so the fixture
+the tests need is in scope wherever they land.
+"""
+
 import re
 from dataclasses import dataclass
 from pathlib import Path, PurePath
@@ -11,6 +19,17 @@ pytest_version_tuple = getattr(pytest, "version_tuple", None)
 
 @dataclass(eq=False)
 class PytestAlembicPlugin:
+    """Bind the built-in tests to exactly one collected file.
+
+    Registered in ``pytest_sessionstart`` rather than at import time, so that disabling
+    the plugin means no hooks at all. ``registered`` is instance state guarding against
+    binding the tests twice if the target path is somehow collected more than once.
+
+    Attributes:
+        config: The session config, read for the tests-path option and ``rootpath``.
+        registered: Whether the built-in tests have already been bound.
+    """
+
     config: config.Config
     registered = False
 
@@ -19,6 +38,7 @@ class PytestAlembicPlugin:
     if pytest_version_tuple and pytest_version_tuple >= (8, 1, 0):
 
         def pytest_collect_file(self, file_path, parent):
+            """Collect the built-in tests at *file_path* (pytest >= 8.1 signature)."""
             if self.should_register(file_path):
                 return TestCollector.from_parent(parent, path=file_path)
             return None
@@ -26,6 +46,11 @@ class PytestAlembicPlugin:
     elif pytest_version_tuple and pytest_version_tuple[0] >= 7:
 
         def pytest_collect_file(self, file_path, path, parent):  # type: ignore[misc] # noqa: ARG002
+            """Collect the built-in tests at *file_path* (pytest 7 signature).
+
+            ``path`` is accepted and ignored: pytest 7 passes both the legacy ``py.path``
+            and the new ``pathlib`` argument.
+            """
             if self.should_register(file_path):
                 return TestCollector.from_parent(parent, path=file_path)
             return None
@@ -33,11 +58,23 @@ class PytestAlembicPlugin:
     else:
 
         def pytest_collect_file(self, path, parent):
+            """Collect the built-in tests at *path* (pytest < 7 signature)."""
             if self.should_register(Path(path)):
                 return TestCollector.from_parent(parent, fspath=path)
             return None
 
     def should_register(self, path):
+        """Report whether *path* is the one file the built-in tests should bind to.
+
+        Precedence is command line, then ini, then ``tests/conftest.py``. The comparison
+        is against the path relative to ``rootpath``, so the configured value is written
+        the same way regardless of where pytest was invoked from.
+
+        Returns ``True`` at most once per session; every later call returns ``False``.
+
+        Args:
+            path: The path pytest is currently offering for collection.
+        """
         tests_path = PurePath(
             cast("Optional[str]", self.config.option.pytest_alembic_tests_path)
             or cast("Optional[str]", self.config.getini("pytest_alembic_tests_path"))
@@ -60,12 +97,25 @@ class PytestAlembicPlugin:
 
 
 class TestCollector(pytest.Module):
+    """The synthetic module node under which the built-in tests are collected.
+
+    Presents as a :class:`pytest.Module` so the built-in tests get the same fixture
+    resolution and reporting as any other test module, even though no such module
+    exists on disk.
+    """
+
     def __init__(self, **kwargs):
+        """Suffix the node id and mark every test below it as ``alembic``."""
         super().__init__(**kwargs)
         self._nodeid += "::pytest-alembic"
         self.add_marker("alembic")
 
     def collect(self):
+        """Resolve which built-in tests are enabled and return them as pytest items.
+
+        Returns an empty list unless ``--test-alembic`` was passed, so merely being
+        bound to a path is not enough to run the built-in tests.
+        """
         assert self.parent
         config = self.parent.config
 
@@ -105,24 +155,58 @@ class TestCollector(pytest.Module):
 
 
 class PytestAlembicItem(pytest.Function):
+    """A single built-in test, reported under a ``[pytest-alembic]`` label."""
+
     def reportinfo(self):
+        """Report line 0 of the bound file, since these tests have no source location."""
         return (self.fspath, 0, f"[pytest-alembic] {self.name}")
 
 
 @dataclass(frozen=True)
 class PytestAlembicTest:
+    """One built-in test function, paired with how it is opted into.
+
+    Attributes:
+        raw_name: The function name as defined, including the ``test_`` prefix.
+        function: The test function itself.
+        is_experimental: Whether the test must be included explicitly.
+    """
+
     raw_name: str
     function: Callable
     is_experimental: bool
 
     @property
     def name(self):
+        """The name used in options and reports, without the ``test_`` prefix.
+
+        Examples:
+            >>> PytestAlembicTest("test_upgrade", lambda: None, False).name
+            'upgrade'
+        """
         # Chop off the "test_" prefix.
         return self.raw_name[5:]
 
 
 @dataclass
 class OptionResolver:
+    """Resolve the include/exclude options into the set of tests to run.
+
+    The ``include*``/``exclude`` methods return ``self`` so the options can be applied
+    in one chained expression, in whatever order they were read. Resolution is deferred
+    to :meth:`tests`, because an unrecognised name can only be detected once every
+    option has been collected.
+
+    ``None`` and empty are deliberately different for ``included_tests``: ``None`` means
+    "not specified, so use the defaults", while empty means "specified as nothing".
+
+    Attributes:
+        available_tests: Every collected test, keyed by prefix-stripped name.
+        included_tests: Explicitly included default tests, or ``None``.
+        included_experimental_tests: Explicitly included experimental tests, or ``None``.
+        excluded_tests: Explicitly excluded tests, or ``None``.
+    """
+
     available_tests: Dict[str, PytestAlembicTest]
 
     included_tests: Optional[List[str]] = None
@@ -136,6 +220,16 @@ class OptionResolver:
         default=True,
         experimental=True,
     ):
+        """Collect the built-in test functions into a new resolver.
+
+        Discovery is by naming convention: any ``test_``-prefixed attribute of
+        :mod:`pytest_alembic.tests` or its ``experimental`` submodule. See the comment
+        below for why the imports stay function-local.
+
+        Args:
+            default: Whether to collect the stable built-in tests.
+            experimental: Whether to collect the experimental tests.
+        """
         # Imported here rather than at module scope to contain the blast radius of a
         # broken alembic. This module is reached from `pytest_alembic.plugin`, the
         # pytest11 entry point, so it loads during pytest startup for every project
@@ -171,6 +265,11 @@ class OptionResolver:
         return cls(all_tests)
 
     def include(self, *tests):
+        """Add *tests* to the explicit include list, and return ``self`` for chaining.
+
+        Specifying any include is what suppresses the default selection, so an empty
+        call is a no-op rather than a way to select nothing.
+        """
         if tests:
             if self.included_tests is None:
                 self.included_tests = []
@@ -179,6 +278,11 @@ class OptionResolver:
         return self
 
     def include_experimental(self, *tests):
+        """Add experimental *tests* to the include list, and return ``self``.
+
+        Tracked separately from :meth:`include` because experimental tests are never
+        selected by default.
+        """
         if tests:
             if self.included_experimental_tests is None:
                 self.included_experimental_tests = []
@@ -187,6 +291,10 @@ class OptionResolver:
         return self
 
     def exclude(self, *tests):
+        """Add *tests* to the exclude list, and return ``self`` for chaining.
+
+        Exclusions are applied after inclusions, so naming a test in both drops it.
+        """
         if tests:
             if self.excluded_tests is None:
                 self.excluded_tests = []
@@ -195,9 +303,18 @@ class OptionResolver:
         return self
 
     def sorted_tests(self):
+        """The resolved tests in a stable order, so collection order is reproducible."""
         return sorted(self.tests(), key=lambda t: t.raw_name)
 
     def tests(self):
+        """Resolve the options into the selected tests.
+
+        Every unrecognised name is gathered before raising, so a typo in one option does
+        not hide a typo in another.
+
+        Raises:
+            ValueError: If any included or excluded name is not a known test.
+        """
         selected_tests = []
         invalid_tests = []
 
@@ -233,6 +350,25 @@ class OptionResolver:
 
 
 def parse_test_names(raw_test_names):
+    r"""Split a comma- or newline-separated option value into a set of test names.
+
+    Both separators are accepted because pytest ini values are commonly written across
+    several lines, while command-line values are comma-separated. Blank entries are
+    dropped, so trailing separators and indentation are harmless.
+
+    Args:
+        raw_test_names: The raw option value.
+
+    Examples:
+        >>> sorted(parse_test_names("upgrade, single_head_revision"))
+        ['single_head_revision', 'upgrade']
+
+        >>> sorted(parse_test_names("upgrade,\n  single_head_revision,\n"))
+        ['single_head_revision', 'upgrade']
+
+        >>> parse_test_names("")
+        set()
+    """
     test_names = re.split(r"[,\n]", raw_test_names)
 
     result = set()

--- a/uv.lock
+++ b/uv.lock
@@ -280,6 +280,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1085,6 +1094,25 @@ wheels = [
 ]
 
 [[package]]
+name = "interrogate"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "colorama" },
+    { name = "py" },
+    { name = "tabulate", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tabulate", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/22/74f7fcc96280eea46cf2bcbfa1354ac31de0e60a4be6f7966f12cef20893/interrogate-1.7.0.tar.gz", hash = "sha256:a320d6ec644dfd887cc58247a345054fc4d9f981100c45184470068f4b3719b0", size = 159636, upload-time = "2024-04-07T22:30:46.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/c9/6869a1dcf4aaf309b9543ec070be3ec3adebee7c9bec9af8c230494134b9/interrogate-1.7.0-py3-none-any.whl", hash = "sha256:b13ff4dd8403369670e2efe684066de9fcb868ad9d7f2b4095d8112142dc9d12", size = 46982, upload-time = "2024-04-07T22:30:44.277Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1747,6 +1775,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1968,6 +2005,7 @@ dev = [
     { name = "coverage", version = "7.15.4", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
     { name = "greenlet", version = "3.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "greenlet", version = "3.5.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "interrogate" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "psycopg2-binary" },
@@ -2010,6 +2048,7 @@ dev = [
     { name = "asyncpg" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.4.4" },
     { name = "greenlet", specifier = ">=3.0" },
+    { name = "interrogate", specifier = ">=1.7" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "psycopg2-binary" },
     { name = "pytest", specifier = ">=8.3.2" },
@@ -2673,6 +2712,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rebased onto `main`. Two findings from the same quality pass turned out to be
**already fixed upstream** while this was being written, so they are no longer here:

- The `plugin/fixtures.py` import cycle (#181) — 4a4546a landed the byte-identical
  change, including the same `migration_context` rename for the same
  `UnboundLocalError` reason. My duplicate commit is dropped.
- The `m2r2` → `mistune` advisories — 29d968e replaced it with myst-parser and made
  `make audit-all` gating.

Three commits remain.

## `docs: fix README custom-test example for SQLAlchemy 2.0` — closes #179

`README.md` documented `alembic_engine.execute(table.insert(...))`. `Engine.execute`
was removed in SQLAlchemy 2.0, so the first snippet a new user copies raised
`AttributeError` on every version the CI matrix exercises:

```
$ python -c "import sqlalchemy; print(sqlalchemy.__version__, hasattr(sqlalchemy.engine.Engine,'execute'))"
2.0.52 False
```

It also referenced an undefined `table`. The example now uses
`alembic_runner.insert_into` for the setup — matching what
`docs/source/custom_tests.rst` already documents — and the 2.0 connection API for the
read-back.

Verified by extracting the fence *verbatim from README.md* and running it against a
real alembic project on sqlite: 1 passed. No existing gate catches this class of bug:
the fence parses fine, and the call sits in a function body that is never invoked.

## `docs: document the plugin layer` — closes #180

`plugin/hooks.py` was at 0% docstring coverage, `plugin/plugin.py` at 5%,
`plugin/error.py` at 25% — the least documented part of the package, and the part a
contributor has to read to understand how the built-in tests become pytest items.

All three are now at 100%, moving the total **48.3% → 71.7%**. The docstrings record
reasoning that is not evident from the code: why registration happens in
`pytest_sessionstart` rather than at import time, why `None` and empty differ for
`included_tests`, and why `AlembicTestFailure` subclasses `AssertionError`. Two
doctests cover the pure functions, so they are checked by `--doctest-modules` rather
than only read.

One point of care on the rebase: `collect_test_definitions` now carries both a
docstring and the blast-radius comment added by 4a4546a. My original docstring
explained the function-local imports as cycle avoidance — the rationale that commit
explicitly corrected — so that sentence is gone and the docstring defers to the
comment instead.

The interrogate floor ratchets 44 → 70, following the convention its config comment
already states.

## `build: gate docstring coverage with interrogate` — closes #170

`[tool.interrogate]` already existed but nothing invoked it, so the documented
proportion could still drift downward unnoticed. Three steps close that: `interrogate`
declared in the dev group (locked in `uv.lock` rather than floating on `uvx`), a
`make docs-coverage` target passing **no flags** so a local run and CI measure the same
thing, and a CI job outside the test matrix — for the same reason the `audit` job
documents, the answer is identical for all 20 entries.

## Verification

All gates green on the rebased branch:

- `make lint` — ruff check, `ruff format --check` (268 files), `mypy src tests` (31 modules): clean
- `make test` — **122 passed** (up from 120: the two new doctests), coverage 95% against the 93 floor
- `make docs-coverage` — 71.7% against the new 70 floor
- `make audit-all` — clean, confirming the new dev dependency introduces no advisory now that this gate blocks
- `actionlint` — clean on the new workflow job
- `uv lock` — no delta, so the merged lockfile is coherent

Still open, and not addressed here: `deptry`'s `_pytest` (DEP001) and `coverage`
(DEP004) reports, and the `OptionResolver.tests` complexity (CC 14).

Note the branch name still says `import-cycle`; that commit is no longer part of this
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
