### PR TITLE
ci: gate the sphinx docs build, at zero warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,28 @@ jobs:
       - name: Check docstring coverage
         run: make docs-coverage
 
+  docs:
+    # The documentation build, as a gate. Outside the test matrix for the same
+    # reason `audit` and `docs-coverage` document above: the .rst sources do not
+    # vary by matrix entry. Until this existed, the only thing that ever built
+    # these docs was readthedocs, *after* the merge — so a broken cross-reference
+    # was reported by a third-party service in a post-merge email rather than by
+    # the pull request that introduced it.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Build the documentation
+        run: make docs
+
   finish:
     needs:
       - test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build test lint format docs-coverage audit audit-all publish changelog
+.PHONY: install build test lint format docs docs-coverage audit audit-all publish changelog
 .DEFAULT_GOAL := test
 
 help:  ## Show this help
@@ -26,6 +26,13 @@ lint:  ## Check lint, formatting and types (ruff, mypy)
 format:  ## Apply ruff fixes and formatting in place
 	uv run ruff check --fix src tests examples
 	uv run ruff format src tests examples
+
+docs:  ## Build the HTML documentation (sphinx)
+	# `--group docs` because `make install` runs a bare `uv sync`, which does not
+	# include that group. `-W` holds the build at zero warnings: a broken
+	# cross-reference or an unlexable code block fails here rather than quietly
+	# degrading a rendered page on readthedocs after the merge.
+	uv run --group docs sphinx-build -W -b html docs/source docs/build/html
 
 docs-coverage:  ## Check docstring coverage (interrogate)
 	# No flags: every threshold and exclusion lives in [tool.interrogate] in

--- a/docs/source/experimental_tests.rst
+++ b/docs/source/experimental_tests.rst
@@ -19,13 +19,14 @@ identify the source module from which the :code:`env.py` is loading its
 :code:`MetaData` and automatically search in that module/package
 
 .. code-block:: toml
-   :caption: pyproject.toml/setup.cfg/pytest.ini
+   :caption: pyproject.toml
 
-   # pyproject.toml
    [tool.pytest.ini_options]
    pytest_alembic_include_experimental = 'all_models_register_on_metadata'
 
-   # or setup.cfg/pytest.ini
+.. code-block:: ini
+   :caption: setup.cfg/pytest.ini
+
    [pytest]
    pytest_alembic_include_experimental = all_models_register_on_metadata
 
@@ -158,13 +159,14 @@ the changes performed in the upgrade.
 Enabling downgrade_leaves_no_trace (TL;DR)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code-block:: toml
-   :caption: pyproject.toml/setup.cfg/pytest.ini
+   :caption: pyproject.toml
 
-   # pyproject.toml
    [tool.pytest.ini_options]
    pytest_alembic_include_experimental = 'downgrade_leaves_no_trace'
 
-   # or setup.cfg/pytest.ini
+.. code-block:: ini
+   :caption: setup.cfg/pytest.ini
+
    [pytest]
    pytest_alembic_include_experimental = downgrade_leaves_no_trace
 


### PR DESCRIPTION
Closes #188.

`build.yml` invokes every gate the `Makefile` has — `lint`, `test`, `audit`, `audit-all`, `docs-coverage` — except the documentation build. Ten `.rst` files, a five-package `docs` dependency group, a `docs/Makefile` and a `readthedocs.yml`, and nothing in CI touched any of it: the only thing that ever built these docs was readthedocs, *after* the merge.

## What changed

**A `docs` target.** One bare target, configuration in the invocation rather than scattered flags, consistent with the rest of the file:

```make
docs:  ## Build the HTML documentation (sphinx)
	uv run --group docs sphinx-build -W -b html docs/source docs/build/html
```

`--group docs` because `make install` runs a bare `uv sync`, which does not include that group. Output goes to `docs/build/html`, already covered by the `build/` entry in `.gitignore`.

**A CI job that runs it**, modelled on `docs-coverage` — outside the test matrix for the reason that job's own comment gives, since the `.rst` sources do not vary by matrix entry.

**The two pre-existing warnings, fixed** — which is what makes `-W` viable in the same PR rather than a follow-up. `experimental_tests.rst:21` and `:160` were both a single block marked `toml` containing a pyproject snippet *and* a `setup.cfg`/`pytest.ini` snippet:

```rst
.. code-block:: toml
   :caption: pyproject.toml/setup.cfg/pytest.ini

   # pyproject.toml
   [tool.pytest.ini_options]
   pytest_alembic_include_experimental = 'downgrade_leaves_no_trace'

   # or setup.cfg/pytest.ini
   [pytest]
   pytest_alembic_include_experimental = downgrade_leaves_no_trace
```

That is not valid TOML, so pygments failed to lex it and fell back to plain text — the rendered page lost its highlighting and nobody found out, because no build asserted on it. Each is now one `toml` block and one `ini` block, so both halves highlight correctly.

Doing it in this order means the gate lands green and *stays* green, rather than arriving as `continue-on-error` — which `build.yml` already records this project deciding against for the audit job, for the same reason.

## Verification

- `make docs` → `build succeeded.` under `-W`. On `main` the same command exits non-zero on the two warnings above.
- `make help` lists `docs` alongside `test`, `lint` and `docs-coverage`.
- `build.yml` parses; jobs are now `test, audit, docs-coverage, docs, finish`.

## Two notes for the reviewer

- The new job's `uses:` are **SHA-pinned**, matching #191 (which pins the other ten). If that merges first the file stays consistent; if it does not, this job is still pinned rather than adding an eleventh mutable tag.
- `-W` makes the build fail on *any* warning, including a failed intersphinx inventory fetch. `conf.py` points `sqlalchemy` at `https://docs.sqlalchemy.org/en/13/objects.inv` — a pinned old version. That URL going away would show up as a red docs job rather than as a documentation problem. Out of scope here, but worth knowing where to look if this job ever fails for a reason unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)