### PR TITLE
test: take coverage to 100% and raise the floor to match

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,19 @@ docs = ["myst-parser", "sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints",
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-# Ratcheted floor. Held below the ~95% actually observed locally, because the CI
-# matrix skips the asyncio tests on sqlalchemy versions without asyncio support,
-# which legitimately lowers coverage on those entries.
-fail_under = 93
+# The ratchet has reached the top, like [tool.interrogate] below: every statement
+# and every branch under `src` is executed by the suite, so the floor is the measured
+# number. A 100% floor is the only one that cannot silently erode -- anything less
+# lets a new untested path hide inside the slack.
+#
+# The previous floor of 93 was set because the CI matrix skipped the asyncio tests on
+# sqlalchemy versions without asyncio support. That reason is gone: the matrix pins a
+# single sqlalchemy (2.0.40), so no entry skips them any more.
+#
+# Each matrix entry enforces this on its own -- `make test` runs the report per job --
+# so what is excluded below has to be excluded for *every* entry, not just this one.
+# `branch = true` under [tool.coverage.run] means partial branches count too.
+fail_under = 100
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:", "if __name__ == .__main__.:"]
 
 [tool.ruff]

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -36,7 +36,14 @@ class PytestAlembicPlugin:
 
     # Some weird decisions were made by pytest it seems like. There is not an obvious
     # way to support both <7 and >=7 without weird nonsense like this.
-    if pytest_version_tuple and pytest_version_tuple >= (8, 1, 0):
+    #
+    # Excluded from coverage, on the whole construct: exactly one of these three
+    # variants is defined in any given interpreter, so no single run can execute the
+    # other two. The CI matrix runs both pytest 7 and pytest 8, and each entry enforces
+    # the coverage floor on its own, so a run that covered them all does not exist. The
+    # bodies are three lines of identical logic behind three different signatures; what
+    # they do is exercised through the pytester-based tests either way.
+    if pytest_version_tuple and pytest_version_tuple >= (8, 1, 0):  # pragma: no cover
 
         def pytest_collect_file(
             self, file_path: Path, parent: pytest.Collector
@@ -46,7 +53,7 @@ class PytestAlembicPlugin:
                 return TestCollector.from_parent(parent, path=file_path)
             return None
 
-    elif pytest_version_tuple and pytest_version_tuple[0] >= 7:
+    elif pytest_version_tuple and pytest_version_tuple[0] >= 7:  # pragma: no cover
 
         def pytest_collect_file(  # type: ignore[misc]
             self,
@@ -63,7 +70,7 @@ class PytestAlembicPlugin:
                 return TestCollector.from_parent(parent, path=file_path)
             return None
 
-    else:
+    else:  # pragma: no cover
 
         def pytest_collect_file(  # type: ignore[misc]
             self, path: Any, parent: pytest.Collector

--- a/src/pytest_alembic/runner.py
+++ b/src/pytest_alembic/runner.py
@@ -154,9 +154,9 @@ class MigrationContext:
 
         self.command_executor.execute_fn(get_current)
 
-        if current:
-            return current
-        return "base"
+        # No fallback needed: `current` starts as "base" and `get_current` only ever
+        # reassigns it to a revision hash.
+        return current
 
     def refresh_history(self) -> AlembicHistory:
         """Refresh the context's version of the alembic history.

--- a/src/pytest_alembic/tests/default.py
+++ b/src/pytest_alembic/tests/default.py
@@ -82,22 +82,21 @@ def test_model_definitions_match_ddl(alembic_runner: MigrationContext) -> None:
             autogen_context = AutogenContext(migration_context)
             rendered_upgrade = _render_cmd_body(script.upgrade_ops, autogen_context)
 
-            if not migration_is_empty:
-                message = (
-                    "The models describing the DDL of your database are out of sync with the set of "
-                    "steps described in the revision history. This usually means that someone has "
-                    "made manual changes to the database's DDL, or some model has been changed "
-                    "without also generating a migration to describe that change."
-                )
-                raise AlembicTestFailure(
-                    message,
-                    context=[
-                        (
-                            "The upgrade which would have been generated would look like",
-                            rendered_upgrade,
-                        )
-                    ],
-                )
+            message = (
+                "The models describing the DDL of your database are out of sync with the set of "
+                "steps described in the revision history. This usually means that someone has "
+                "made manual changes to the database's DDL, or some model has been changed "
+                "without also generating a migration to describe that change."
+            )
+            raise AlembicTestFailure(
+                message,
+                context=[
+                    (
+                        "The upgrade which would have been generated would look like",
+                        rendered_upgrade,
+                    )
+                ],
+            )
 
     test_upgrade(alembic_runner)
     alembic_runner.generate_revision(

--- a/src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py
+++ b/src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py
@@ -33,7 +33,7 @@ try:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
     async_engine_cls = True
-except ImportError:
+except ImportError:  # pragma: no cover
     async_engine_cls = False
 
 

--- a/tests/plugin/test_hooks.py
+++ b/tests/plugin/test_hooks.py
@@ -1,0 +1,30 @@
+from unittest import mock
+
+from pytest_alembic.plugin import hooks
+
+
+def test_disabled_plugin_registers_no_hooks() -> None:
+    """Assert `pytest_alembic_enabled = false` means the plugin is never registered.
+
+    The option is honoured at session start rather than at collection time, so a
+    disabled plugin adds no hooks at all instead of adding hooks which decline to
+    collect.
+    """
+    session = mock.Mock()
+    session.config.getini.return_value = False
+
+    hooks.pytest_sessionstart(session)
+
+    session.config.pluginmanager.register.assert_not_called()
+
+
+def test_enabled_plugin_is_registered_under_its_own_name() -> None:
+    """Assert the collection plugin is registered when the option is left on."""
+    session = mock.Mock()
+    session.config.getini.return_value = True
+
+    hooks.pytest_sessionstart(session)
+
+    (plugin, name) = session.config.pluginmanager.register.call_args.args
+    assert name == "pytest-alembic"
+    assert plugin.config is session.config

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -1,6 +1,8 @@
+from unittest import mock
+
 import pytest
 
-from pytest_alembic.plugin.plugin import OptionResolver, parse_test_names
+from pytest_alembic.plugin.plugin import OptionResolver, parse_test_names, PytestAlembicPlugin
 
 pytest_options = (
     "--test-alembic",
@@ -166,3 +168,51 @@ class Test_collect_tests:
         for test in tests:
             assert f"::pytest-alembic::{test}" in stdout
         assert "4 passed" in stdout
+
+
+class Test__chained_options:
+    """The `include`/`exclude` methods accumulate rather than replace.
+
+    Each starts its list at `None` -- "not specified", which is meaningfully different
+    from "specified as nothing" -- and only allocates on the first call. Applying the
+    same option twice is what exercises the already-allocated path.
+    """
+
+    def test_include_accumulates(self) -> None:
+        collector = OptionResolver.collect_test_definitions()
+        collector.include("upgrade").include("single_head_revision")
+
+        assert collector.included_tests == ["upgrade", "single_head_revision"]
+
+    def test_include_experimental_accumulates(self) -> None:
+        collector = OptionResolver.collect_test_definitions()
+        collector.include_experimental("downgrade_leaves_no_trace")
+        collector.include_experimental("all_models_register_on_metadata")
+
+        assert collector.included_experimental_tests == [
+            "downgrade_leaves_no_trace",
+            "all_models_register_on_metadata",
+        ]
+
+    def test_exclude_accumulates(self) -> None:
+        collector = OptionResolver.collect_test_definitions()
+        collector.exclude("upgrade").exclude("single_head_revision")
+
+        assert collector.excluded_tests == ["upgrade", "single_head_revision"]
+
+
+class Test_pytest_itemcollected:
+    def test_item_without_fixtures_is_ignored(self, pytestconfig: pytest.Config) -> None:
+        """Assert a collected node carrying no fixtures is left alone.
+
+        `pytest_itemcollected` sees every collected item, including nodes which are not
+        function items and so have no `fixturenames` at all.
+        """
+        plugin = PytestAlembicPlugin(pytestconfig)
+
+        item = mock.Mock()
+        del item.fixturenames
+
+        plugin.pytest_itemcollected(item)
+
+        item.add_marker.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,3 +62,30 @@ def test_pyproject_toml() -> None:
     with exists, mock_patch("[alembic]", b"[tool.alembic]\nscript_location = 'asdf'"):
         alembic_config = config.make_alembic_config(io.StringIO())
     assert alembic_config.get_main_option("script_location") == "asdf"
+
+
+def test_legacy_alembic_without_toml_support() -> None:
+    """Assert the pre-`pyproject.toml` alembic path still builds a config.
+
+    `_supports_toml` gates two branches, and only one of them is reachable in any given
+    environment -- the installed alembic either has `get_alembic_option` or it does not.
+    Patching it is what lets the legacy branch be exercised on a modern alembic.
+    """
+    config = Config(config_options={"file": "foo.ini"})
+
+    supports_toml = mock.patch("pytest_alembic.config._supports_toml", return_value=False)
+    with supports_toml, mock_patch("[alembic]"):
+        alembic_config = config.make_alembic_config(io.StringIO())
+
+    assert alembic_config.config_file_name == "foo.ini"
+
+
+def test_legacy_alembic_reads_script_location_from_main_option() -> None:
+    """Assert `_get_option` falls back to `get_main_option` without toml support."""
+    config = Config()
+
+    supports_toml = mock.patch("pytest_alembic.config._supports_toml", return_value=False)
+    with supports_toml, mock_patch("[alembic]\nscript_location = legacy"):
+        alembic_config = config.make_alembic_config(io.StringIO())
+
+    assert alembic_config.get_main_option("script_location") == "legacy"

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,8 +1,12 @@
+from io import StringIO
+
+import alembic.config
+import pytest
 from pytest_mock_resources import create_postgres_fixture
 from sqlalchemy import Column, MetaData, Table, types
 from sqlalchemy.engine import Engine
 
-from pytest_alembic.executor import ConnectionExecutor
+from pytest_alembic.executor import CommandExecutor, ConnectionExecutor
 
 metadata = MetaData()
 
@@ -14,3 +18,32 @@ pg = create_postgres_fixture(metadata)
 def test_table_insert(pg: Engine) -> None:
     command_executor = ConnectionExecutor(pg)
     command_executor.table_insert("", [{"name": "who"}], tablename="t")
+
+
+def test_command_error_becomes_runtime_error() -> None:
+    """Assert alembic's `CommandError` is re-raised as a plain `RuntimeError`.
+
+    Callers of `run_command` should not have to import from `alembic.util` to catch a
+    failed command, so the translation happens here rather than at each call site.
+    """
+    command_executor = CommandExecutor(
+        alembic_config=alembic.config.Config(),
+        stdout=StringIO(),
+        stream_position=0,
+        script=None,  # type: ignore[arg-type]  # unused by `run_command`
+    )
+
+    with pytest.raises(RuntimeError):
+        command_executor.run_command("stamp", "abcdef")
+
+
+def test_table_insert_without_a_table_name() -> None:
+    """Assert a row which names no table is rejected rather than silently skipped.
+
+    The table can come from the `tablename` argument or from a `__tablename__` key on
+    the row itself; with neither, there is nothing to insert into.
+    """
+    connection_executor = ConnectionExecutor(connection=None)
+
+    with pytest.raises(ValueError, match="No table name provided"):
+        connection_executor.table_insert("", [{"name": "who"}])

--- a/tests/test_migration_context.py
+++ b/tests/test_migration_context.py
@@ -1,0 +1,124 @@
+"""Direct tests for the `MigrationContext` paths the example-driven suite cannot reach.
+
+Most of `tests/test_runner.py` drives a real alembic history through `pytester`, which
+is the right shape for anything involving migrations actually running. The paths here
+are the opposite: error handling and early returns which need a specific executor
+response rather than a specific migration history, so they are exercised against stubs.
+"""
+
+from typing import Any
+from unittest import mock
+
+import alembic.config
+import alembic.util
+import pytest
+
+from pytest_alembic.config import Config
+from pytest_alembic.revision_data import RevisionData
+from pytest_alembic.runner import MigrationContext
+
+
+def make_command_executor() -> Any:
+    """A stub executor carrying the one real thing `generate_revision` reads."""
+    command_executor = mock.Mock()
+    command_executor.alembic_config = alembic.config.Config()
+    command_executor.alembic_config.attributes["process_revision_directives"] = None
+    return command_executor
+
+
+def make_context(
+    command_executor: Any = None,
+    connection_executor: Any = None,
+    history: Any = None,
+) -> MigrationContext:
+    """Build a `MigrationContext` whose collaborators are stubs."""
+    config = Config()
+    return MigrationContext(
+        command_executor=command_executor or make_command_executor(),
+        revision_data=RevisionData.from_config(config),
+        connection_executor=connection_executor or mock.Mock(),
+        history=history or mock.Mock(),
+        config=config,
+    )
+
+
+def test_raw_command_forwards_to_the_executor() -> None:
+    """Assert `raw_command` is a pass-through to `alembic.command`.
+
+    It is the escape hatch for commands with no dedicated method here, so it must not
+    interpret its arguments -- they go through untouched, and the captured stdout comes
+    straight back.
+    """
+    command_executor = make_command_executor()
+    command_executor.run_command.return_value = ["a line"]
+    context = make_context(command_executor=command_executor)
+
+    result = context.raw_command("history", verbose=True)
+
+    assert result == ["a line"]
+    command_executor.run_command.assert_called_once_with("history", verbose=True)
+
+
+def test_insert_into_without_data_is_a_no_op() -> None:
+    """Assert `insert_into` with no data touches neither the connection nor the schema.
+
+    `managed_upgrade` calls this for every revision, and most revisions have no
+    configured data, so the empty case has to be free rather than reflecting a table.
+    """
+    connection_executor = mock.Mock()
+    context = make_context(connection_executor=connection_executor)
+
+    context.insert_into("foo", None)
+
+    connection_executor.table_insert.assert_not_called()
+
+
+def test_generate_revision_does_not_refresh_history_when_preventing_generation() -> None:
+    """Assert the history is only re-parsed when a revision file was actually written.
+
+    Re-parsing is the expensive step `refresh_history` documents, so it is skipped when
+    nothing can have changed on disk.
+    """
+    command_executor = make_command_executor()
+    command_executor.run_command.return_value = ["ok"]
+    context = make_context(command_executor=command_executor)
+
+    with mock.patch.object(MigrationContext, "refresh_history") as refresh_history:
+        result = context.generate_revision(message="test revision")
+
+    assert result == ["ok"]
+    refresh_history.assert_not_called()
+
+
+class Test_managed_downgrade:
+    """`managed_downgrade` distinguishes one alembic error from every other."""
+
+    @staticmethod
+    def context_raising(error: Exception) -> MigrationContext:
+        command_executor = make_command_executor()
+        command_executor.downgrade.side_effect = error
+
+        history = mock.Mock()
+        history.revision_window.return_value = [("a1", "b2")]
+
+        return make_context(command_executor=command_executor, history=history)
+
+    def test_invalid_downgrade_target_is_tolerated(self) -> None:
+        """Assert a branch alembic cannot downgrade past is walked over, not raised.
+
+        A branched history yields `(from, to)` pairs which are not all reachable from
+        one another; alembic rejects those, and it is not a failure of the migrations.
+        """
+        error = alembic.util.CommandError(
+            "Destination b2 is not a valid downgrade target from current head(s)"
+        )
+        context = self.context_raising(error)
+
+        assert context.managed_downgrade("a1", current="b2", return_current=False) is None
+
+    def test_other_command_errors_propagate(self) -> None:
+        """Assert an unrelated alembic failure is not swallowed by that tolerance."""
+        context = self.context_raising(alembic.util.CommandError("Can't locate revision"))
+
+        with pytest.raises(alembic.util.CommandError, match="Can't locate revision"):
+            context.managed_downgrade("a1", current="b2", return_current=False)

--- a/tests/test_revision_data.py
+++ b/tests/test_revision_data.py
@@ -13,10 +13,22 @@ def test_from_config_empty_data() -> None:
 
 
 def test_revision_spec_input() -> None:
-    config = Config(
-        {"before_revision_data": RevisionSpec({}), "at_revision_data": RevisionSpec({})}
-    )
-    RevisionData.from_config(config)
+    """Assert an already-parsed `RevisionSpec` is accepted as configuration.
+
+    Passed as the dataclass fields rather than inside `config_options`: the first
+    positional argument of `Config` is `config_options`, so keys placed there never
+    reach `before_revision_data`/`at_revision_data` at all.
+    """
+    before = RevisionSpec({"foo": {"id": 1}})
+    at = RevisionSpec({"bar": {"id": 2}})
+    config = Config(before_revision_data=before, at_revision_data=at)
+
+    revision_data = RevisionData.from_config(config)
+
+    # `RevisionSpec.parse` hands back the very object it was given, rather than
+    # re-wrapping it.
+    assert revision_data.before_revision_data is before
+    assert revision_data.at_revision_data is at
 
 
 def test_get_before_single_item() -> None:

--- a/tests/tests/experimental/test_all_models_register_on_metadata.py
+++ b/tests/tests/experimental/test_all_models_register_on_metadata.py
@@ -1,12 +1,15 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from sqlalchemy.engine.url import make_url, URL
 
 from pytest_alembic.plugin.error import AlembicTestFailure
 from pytest_alembic.tests.experimental.all_models_register_on_metadata import (
     get_full_tableset,
+    parse_collection_output,
     traverse_modules,
+    url_to_string,
 )
 
 
@@ -104,3 +107,49 @@ class Test_get_full_tableset:
         with pytest.raises(AlembicTestFailure) as e:
             get_full_tableset("pytest_alembic")
         assert "Unable to locate a MetaData" in str(e.value)
+
+
+class Test_parse_collection_output:
+    """The subprocess reports through stdout, which it does not have to itself."""
+
+    def test_ignores_surrounding_noise(self) -> None:
+        payload = '<pytest-alembic>{"modules": [], "tables": ["t1"]}</pytest-alembic>'
+
+        assert parse_collection_output(payload) == {"modules": [], "tables": ["t1"]}
+
+    def test_missing_payload_is_a_bug_here(self) -> None:
+        """Assert output with no sentinel raises, carrying the raw output.
+
+        No payload means the subprocess never got as far as reporting, which indicates a
+        problem in the collection script rather than in the migrations under test -- so
+        the raw output is what the reader needs to see.
+        """
+        with pytest.raises(RuntimeError, match="alembic exploded"):
+            parse_collection_output("alembic exploded")
+
+
+class Test_url_to_string:
+    """The password has to survive: the string is handed to a subprocess which connects.
+
+    Which call renders it has changed across sqlalchemy versions, so the alternatives
+    are tried in turn.
+    """
+
+    def test_modern_url_keeps_the_password(self) -> None:
+        url = make_url("postgresql://user:hunter2@localhost/dev")
+
+        assert url_to_string(url) == "postgresql://user:hunter2@localhost/dev"
+
+    def test_url_without_the_hide_password_argument(self) -> None:
+        class OldUrl:
+            def render_as_string(self) -> str:
+                return "rendered"
+
+        assert url_to_string(cast("URL", OldUrl())) == "rendered"
+
+    def test_url_without_render_as_string_at_all(self) -> None:
+        class AncientUrl:
+            def __str__(self) -> str:
+                return "stringified"
+
+        assert url_to_string(cast("URL", AncientUrl())) == "stringified"

--- a/tests/tests/experimental/test_collect_clean_alembic_environment.py
+++ b/tests/tests/experimental/test_collect_clean_alembic_environment.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 import pytest
 from sqlalchemy import MetaData
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -14,6 +16,7 @@ from pytest_alembic.tests.experimental.all_models_register_on_metadata import (
     parse_collection_output,
 )
 from pytest_alembic.tests.experimental.collect_clean_alembic_environment import (
+    create_connectable,
     environment_context_fn,
     get_referrer_module,
     identify_modules,
@@ -91,3 +94,22 @@ class Test_get_referrer_module:
         referrer = {"__loader__": Loader(name)}
         actual_loader_name = list(get_referrer_module(referrer))
         assert actual_loader_name == loader_name
+
+
+class Test_create_connectable:
+    """The subprocess builds its own engine, sync or async, from a bare URL.
+
+    Neither call connects, so both are safe to make here; what is under test is which
+    factory gets used, since the async one is imported lazily and is not importable on
+    every supported sqlalchemy version.
+    """
+
+    def test_sync(self) -> None:
+        engine = create_connectable("sqlite://")
+
+        assert isinstance(engine, Engine)
+
+    def test_async(self) -> None:
+        engine = create_connectable("postgresql+asyncpg://user@localhost/dev", async_=True)
+
+        assert isinstance(engine, AsyncEngine)

--- a/tests/tests/experimental/test_downgrade_leaves_no_trace.py
+++ b/tests/tests/experimental/test_downgrade_leaves_no_trace.py
@@ -1,0 +1,39 @@
+from collections.abc import Iterator
+
+import pytest
+import sqlalchemy
+from sqlalchemy.engine import Connection
+
+from pytest_alembic.tests.experimental.downgrade_leaves_no_trace import WrappingConnection
+
+
+@pytest.fixture
+def connection() -> Iterator[Connection]:
+    engine = sqlalchemy.create_engine("sqlite://")
+    try:
+        with engine.connect() as conn:
+            yield conn
+    finally:
+        engine.dispose()
+
+
+class Test_WrappingConnection:
+    """A live connection presented as though it were an engine.
+
+    Alembic's `env.py` conventionally calls `connect()` on what it is given, which would
+    open a *second* connection and so land outside the transaction this test holds open.
+    """
+
+    def test_connect_yields_the_same_connection(self, connection: Connection) -> None:
+        wrapper = WrappingConnection(connection)
+
+        with wrapper.connect() as yielded:
+            assert yielded is connection
+
+        # And it is still open afterwards, for the next caller.
+        assert not connection.closed
+
+    def test_every_other_attribute_falls_through(self, connection: Connection) -> None:
+        wrapper = WrappingConnection(connection)
+
+        assert wrapper.dialect is connection.dialect


### PR DESCRIPTION
**Builds on #193 — merge that first.** This branch contains #193's commit as its parent, so the diff below currently shows both; once #193 merges, this PR's diff collapses to its own single commit automatically. (A stacked base is not possible here: the base of a cross-fork PR has to be a branch in this repository, and only `main` is.) It is stacked rather than independent because both changes touch nearly every line of `tests/`, and new tests have to be annotated to satisfy #193's `disallow_untyped_defs` anyway.

**Review the second commit**, `test: take coverage to 100% and raise the floor to match`.

## Why

`fail_under = 93` against ~95% measured left 35 unexecuted statements and 15 partial branches with nowhere to show up. That is the same slack `[tool.interrogate]` was ratcheted out of in #185 — a floor below the measured number lets a new untested path hide inside the gap instead of failing the build.

The comment on the old floor was also stale:

> Held below the ~95% actually observed locally, because the CI matrix skips the asyncio tests on sqlalchemy versions without asyncio support

The matrix now pins a single sqlalchemy (`2.0.40`), so no entry skips those tests any more.

## Most of the gap was reachable, and is now tested

24 new tests, in three new files and five existing ones:

| what | where |
| --- | --- |
| the pre-`pyproject.toml` alembic path, both branches of `_supports_toml` | `test_config.py` |
| `CommandError` → `RuntimeError`; a row naming no table | `test_executor.py` |
| `raw_command`; `insert_into` with no data; `generate_revision` not refreshing history; both halves of `managed_downgrade`'s error handling | `test_migration_context.py` *(new)* |
| the disabled-plugin session hook, and the enabled one | `plugin/test_hooks.py` *(new)* |
| chained `include`/`include_experimental`/`exclude`; an item with no fixtures | `plugin/test_plugin.py` |
| `parse_collection_output` with no payload; `url_to_string`'s two fallbacks | `test_all_models_register_on_metadata.py` |
| `create_connectable`, sync and async | `test_collect_clean_alembic_environment.py` |
| `WrappingConnection` | `test_downgrade_leaves_no_trace.py` *(new)* |

`test_migration_context.py` is stub-driven on purpose, and says so: `tests/test_runner.py` drives real histories through `pytester`, which is right for anything where migrations actually run, but these paths need a particular *executor response* rather than a particular history.

## One test was silently doing nothing

`test_revision_spec_input` passed its specs inside `config_options` — the first positional argument of `Config` — so they never reached `before_revision_data`/`at_revision_data`, `RevisionSpec.parse` was never called with a `RevisionSpec`, and the test asserted nothing at all. It now constructs the fields it meant to and asserts that `parse` hands back the very object it was given.

## Two dead branches removed rather than tested

Both were unreachable, so a test for them could not be written honestly:

- `MigrationContext.current` ended `if current: return current / return "base"`. `current` is initialised to `"base"` and `get_current` only ever reassigns it to a revision hash, so the guard can never be False.
- `test_model_definitions_match_ddl` re-tested `migration_is_empty` inside the block that had just established it.

## Two exclusions, with the reasoning recorded at the site

- **The version-dispatched `pytest_collect_file` variants.** Exactly one of the three is defined in any given interpreter, so no single run can execute the other two — and since the matrix runs both pytest 7 and pytest 8 and *each entry enforces the floor on its own*, a run that covers all three does not exist. What they do is exercised through the pytester-based tests either way.
- **The asyncio `ImportError` fallback**, matching the `DeclarativeMeta` one immediately above it, which was already excluded for the same reason.

## Verification

- `make test` → **148 passed**, `TOTAL 895 0 208 0 100%` — every statement and every branch, in every file.
- `make lint` → clean on 34 files, including the new tests under #193's `disallow_untyped_defs`.
- `make docs-coverage` → 100%, unchanged.

## One thing to know about the floor

Because each matrix entry enforces it independently, anything version-conditional has to be excluded for *every* entry, not just this one. The remaining sensitivity is `test_pyproject_toml`, which skips itself when alembic lacks `get_alembic_option` — alembic is unpinned in the matrix so it always resolves modern, but if it ever did not, that entry would drop below 100 rather than merely losing a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)