### PR TITLE
build: drop the private _pytest import and gate dependency hygiene

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,26 @@ jobs:
       - name: Check docstring coverage
         run: make docs-coverage
 
+  deps:
+    # Dependency hygiene: an import with no declaration, or a declaration with no
+    # import. Outside the test matrix for the reason `audit` and `docs-coverage`
+    # document above -- the answer comes from `pyproject.toml` and `src`, neither of
+    # which varies by matrix entry.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Check dependency hygiene
+        run: make deps
+
   docs:
     # The documentation build, as a gate. Outside the test matrix for the same
     # reason `audit` and `docs-coverage` document above: the .rst sources do not

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build test lint format docs docs-coverage audit audit-all publish changelog
+.PHONY: install build test lint format deps docs docs-coverage audit audit-all publish changelog
 .DEFAULT_GOAL := test
 
 help:  ## Show this help
@@ -26,6 +26,12 @@ lint:  ## Check lint, formatting and types (ruff, mypy)
 format:  ## Apply ruff fixes and formatting in place
 	uv run ruff check --fix src tests examples
 	uv run ruff format src tests examples
+
+deps:  ## Check dependency hygiene (deptry)
+	# No flags: every exception lives in [tool.deptry] in pyproject.toml, so a local
+	# run and CI measure the same thing. `--group docs` so deptry can introspect the
+	# docs packages too, rather than guessing their module names.
+	uv run --group docs deptry src
 
 docs:  ## Build the HTML documentation (sphinx)
 	# `--group docs` because `make install` runs a bare `uv sync`, which does not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ build-backend = "uv_build"
 dev = [
     "asyncpg",
     "coverage[toml]>=6.4.4",
+    "deptry>=0.20",
     "greenlet>=3.0",
     "interrogate>=1.7",
     "mypy>=1.11",
@@ -162,6 +163,20 @@ incremental = true
 # sqlalchemy, pytest and pytest_mock_resources all ship `py.typed`, so the annotations
 # here are checked against their real signatures either way.
 disallow_untyped_defs = true
+
+[tool.deptry]
+# Dependency hygiene, as a gate. Runs over `src` only: the dev and docs groups exist to
+# support the test suite and the docs build, which deptry would otherwise report as
+# unused because nothing under `src` imports them.
+
+[tool.deptry.per_rule_ignores]
+# DEP004 is "imported but declared as a dev dependency", and here that is deliberate.
+# `collect_clean_alembic_environment` is executed as a subprocess by the experimental
+# `all_models_register_on_metadata` test, and imports coverage only under
+# `if __name__ == "__main__"`, behind a `COVERAGE_PROCESS_START` environment check, so
+# that the subprocess's lines are measured when the suite runs under coverage. It is
+# never reached by a user of this package, so coverage stays a dev dependency.
+DEP004 = ["coverage"]
 
 [tool.interrogate]
 # Docstring *coverage*, as a ratchet. This deliberately complements ruff rather

--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -13,7 +13,6 @@ from pathlib import Path, PurePath
 from typing import Any, cast
 
 import pytest
-from _pytest import config
 
 pytest_version_tuple = getattr(pytest, "version_tuple", None)
 
@@ -31,7 +30,7 @@ class PytestAlembicPlugin:
         registered: Whether the built-in tests have already been bound.
     """
 
-    config: config.Config
+    config: pytest.Config
     registered = False
 
     # Some weird decisions were made by pytest it seems like. There is not an obvious

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,36 @@ toml = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e7/b554568a84197c0a4177b51c9880b55e9861de08d9acfd914a08148a1faa/deptry-0.25.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:30d64d4df1c08bc69de56cb0b4ec1f4cd9fa2e42582347d5b1eb25fd0e401745", size = 1846779, upload-time = "2026-03-18T23:22:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/38cf5ab4b81fcb1c58909ab0fe1ccc62b36f61c5f7d213a7d0474f620925/deptry-0.25.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:87bcd90f99a98bb059c7580bc315c3f87d97fe2db725530030bc974176834735", size = 1758420, upload-time = "2026-03-18T23:22:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/fb/234c333d5dfcc810bb3ca5b3b420355bdd759901c75e41f0441a9871a1cd/deptry-0.25.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f31eb5c520651b102568dd91f738222b250a3e44c9e95d4941322109b8d40a", size = 1870345, upload-time = "2026-03-18T23:22:29.734Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/cb63e5210d1ba36cf68cdc0e4fdea73e48f80ac3b7680228816f39ff696a/deptry-0.25.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df88952a2bab7517ef23cb304b979199b28449e5d9db2e9ba9bc27a286ac852b", size = 1922759, upload-time = "2026-03-18T23:22:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/8c/e079c44ed98464930e83ca54ea5d40fec522d234e8428e06a1be7f6c7a9a/deptry-0.25.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e6f7b8fa72932e51e86799b10dcd29381b2132dc799c790dca3b28ab08dffb28", size = 2049576, upload-time = "2026-03-18T23:22:12.797Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f2/6a89ad9e5e8e9d37def57a28020d6d7fbcf900b2e5f4dfbbace349cdca91/deptry-0.25.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e3fa3321078e11cd1ac3f10ce3ff0547731c53f9253b87c757a8749c76fe8fa9", size = 2144676, upload-time = "2026-03-18T23:22:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/b3358690a1a47381d995c3d3587798ab2cd086baf4b839e35183599aa2e1/deptry-0.25.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:03c032c32492fde434736954fbcaff09c02bf207b0f793b77e9040300e34b344", size = 1715518, upload-time = "2026-03-18T23:22:20.486Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1410,6 +1440,7 @@ dev = [
     { name = "anyio" },
     { name = "asyncpg" },
     { name = "coverage", extra = ["toml"] },
+    { name = "deptry" },
     { name = "greenlet" },
     { name = "interrogate" },
     { name = "mypy" },
@@ -1446,6 +1477,7 @@ dev = [
     { name = "anyio" },
     { name = "asyncpg" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.4.4" },
+    { name = "deptry", specifier = ">=0.20" },
     { name = "greenlet", specifier = ">=3.0" },
     { name = "interrogate", specifier = ">=1.7" },
     { name = "mypy", specifier = ">=1.11" },
@@ -1588,6 +1620,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #200.

`uvx deptry src` reported two findings. They look alike and want opposite treatments.

## The one that is a real defect

`src/pytest_alembic/plugin/plugin.py:16` did `from _pytest import config`, used for exactly one thing — the annotation `config: config.Config` at `:34`.

deptry flags it as `DEP001`, imported but not declared. It is *undeclarable*: `_pytest` is pytest's **private** module and no package declares it. That is the actual finding — the deptry error is just how it surfaced. `pytest.Config` is the public spelling of the same type, and `plugin/hooks.py` already uses `pytest.Parser`, `pytest.Config` and `pytest.Session`, so this brings the one holdout in line rather than introducing a new convention.

Verified present on pytest 7.0.0, 8.3.5 and 9.1.1 — the versions the CI matrix installs — since the annotation is evaluated at import time.

## The one that is deliberate

`src/pytest_alembic/tests/experimental/collect_clean_alembic_environment.py:136` imports `coverage`, which is declared dev-only (`DEP004`). That is correct as written: the import sits under `if __name__ == "__main__"`, behind `os.environ.get("COVERAGE_PROCESS_START")`, and exists so the collection subprocess's lines are measured when the suite runs under coverage. A user of this package never reaches it, so `coverage` should stay a dev dependency.

Recorded as a `[tool.deptry.per_rule_ignores]` exception with the reasoning inline, rather than changed.

## Wiring it in

The finding asked for the gate to be wired in "so it stays that way", suggesting `make lint`. I put it in its own `make deps` target and CI job instead, for the reason this repo already documents on `audit` and `docs-coverage`:

> Deliberately outside the test matrix […] the lockfile is identical for every matrix entry, so auditing it 20 times would report the same answer 20 times.

deptry's answer comes from `pyproject.toml` and `src`, neither of which varies by matrix entry — whereas `make lint` runs in all 28 of them. Same reasoning, same placement.

`deptry` is declared in the dev group rather than run through `uvx`, matching how `interrogate` and `mypy` are handled. The target passes `--group docs` so deptry can introspect the docs packages instead of guessing their module names — that is what turns five `Assuming the corresponding module name of…` warnings into a silent pass.

## Verification

- `make deps` → `Success! No dependency issues found.`, no warnings. On `main` the same check reports `Found 2 dependency issues.`
- `make lint` → clean on 34 modules.
- `make test` → 149 passed, coverage still `894 stmts / 208 branches, 0 miss, 100%`.
- `build.yml` parses; jobs are now `test, audit, docs-coverage, deps, docs, finish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)