### PR TITLE
fix: spawn sys.executable for the collection subprocess, not PATH's python

### DIFF
--- a/src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py
+++ b/src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py
@@ -13,6 +13,7 @@ import logging
 import pkgutil
 import re
 import subprocess  # nosec
+import sys
 from collections.abc import Callable, Iterator
 from types import ModuleType
 from typing import Any
@@ -147,7 +148,15 @@ def get_bare_import_tableset(
     """
 
     command = [
-        "python",
+        # `sys.executable`, not the string "python": the child has to import this very
+        # package, so it has to be *this* interpreter. Resolving "python" through PATH
+        # instead finds whichever one happens to be first, which is not the running one
+        # under tox, or under any runner that invokes a venv's interpreter by absolute
+        # path without activating it -- and on Windows is frequently not an interpreter
+        # at all. The failure then surfaces through the `CalledProcessError` handler
+        # below as an `AlembicTestFailure`, i.e. as a problem with the user's migrations
+        # rather than with their environment.
+        sys.executable,
         "-m",
         "pytest_alembic.tests.experimental.collect_clean_alembic_environment",
         url,

--- a/tests/tests/experimental/test_all_models_register_on_metadata.py
+++ b/tests/tests/experimental/test_all_models_register_on_metadata.py
@@ -1,11 +1,14 @@
+import sys
 from collections.abc import Callable
 from typing import Any, cast
+from unittest import mock
 
 import pytest
 from sqlalchemy.engine.url import make_url, URL
 
 from pytest_alembic.plugin.error import AlembicTestFailure
 from pytest_alembic.tests.experimental.all_models_register_on_metadata import (
+    get_bare_import_tableset,
     get_full_tableset,
     parse_collection_output,
     traverse_modules,
@@ -153,3 +156,31 @@ class Test_url_to_string:
                 return "stringified"
 
         assert url_to_string(cast("URL", AncientUrl())) == "stringified"
+
+
+class Test_get_bare_import_tableset:
+    def test_spawns_the_running_interpreter(self) -> None:
+        """Assert the collection subprocess is *this* interpreter, not `PATH`'s `python`.
+
+        The child imports `pytest_alembic` itself, so it has to be the interpreter the
+        parent is running under. Resolving "python" through PATH finds whichever comes
+        first, which is a different one under tox or an unactivated venv, and on Windows
+        is often not an interpreter at all.
+        """
+        payload = '<pytest-alembic>{"modules": ["a.models"], "tables": ["t1"]}</pytest-alembic>'
+        completed = mock.Mock()
+        completed.stdout = payload
+
+        target = "pytest_alembic.tests.experimental.all_models_register_on_metadata.subprocess.run"
+        with mock.patch(target, return_value=completed) as run:
+            modules, tablenames = get_bare_import_tableset("sqlite://")
+
+        assert modules == ["a.models"]
+        assert tablenames == {"t1"}
+
+        command = run.call_args.args[0]
+        assert command[0] == sys.executable
+        assert command[1:3] == [
+            "-m",
+            "pytest_alembic.tests.experimental.collect_clean_alembic_environment",
+        ]


### PR DESCRIPTION
Closes #201.

`get_bare_import_tableset` hard-coded the string `"python"` as the interpreter for the clean-import subprocess:

```python
command = [
    "python",
    "-m",
    "pytest_alembic.tests.experimental.collect_clean_alembic_environment",
    ...
]
```

That resolves through `PATH`, which is not necessarily the interpreter running the tests. The child exists to import *this very package* — so it has to be *this* interpreter, which is exactly what `sys.executable` is.

## Where it breaks

- **tox, or any runner that invokes a venv's interpreter by absolute path without activating it.** `PATH`'s `python` is then the system interpreter, which has no `pytest_alembic` installed, so `python -m pytest_alembic.tests.experimental...` exits non-zero.
- **Windows.** `python` is frequently absent entirely (the launcher is `py`), or is the Microsoft Store stub that opens a store page instead of running anything.

The failure mode is what makes this worth fixing rather than documenting. A non-zero exit is caught at `:165` and re-raised as an `AlembicTestFailure` — so a broken *environment* surfaces to the user as a problem with their *migrations*, pointing them at the wrong thing entirely.

It works in this repo's CI only because `setup-uv` puts the venv's `bin` first on `PATH`, which is why nothing has caught it.

## The test

`Test_get_bare_import_tableset::test_spawns_the_running_interpreter` patches `subprocess.run` and asserts the command's first element is `sys.executable`.

I checked it actually catches the regression rather than just passing: reverting `src/` to `"python"` and re-running gives

```
E         - /Users/…/pytest-alembic/.venv/bin/python
E         + python
```

That is deliberately in the spirit of #197 — the existing coverage of this function came entirely from example runs asserting "N tests passed", which stayed green through the whole bug.

## Verification

- `make test` → **150 passed**, coverage still `896 stmts / 208 branches, 0 miss, 100%`.
- `make lint` → clean on 34 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)