### PR TITLE
chore: bump the version to 0.13.0 for the Python 3.9 drop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-alembic"
-version = "0.12.1"
+version = "0.13.0"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [{ name = "Dan Cardin", email = "ddcardin@gmail.com" }]
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "pytest-alembic"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #203.

`pyproject.toml:3` has read `version = "0.12.1"` since the tag of the same name. In the 78 commits since, `194ecb0` — `chore!: drop Python 3.9, raising the floor to 3.10` — raised `requires-python` to `>=3.10`. It is the only `!`-marked commit in that range, and it is genuinely breaking: installing on 3.9 stops working.

For a `0.x` package the breaking bump is the minor, so **0.13.0**.

Nothing was wrong yet — no release had been cut. The risk was that the version string and the `!` commit live in different places with nothing connecting them, so the next release could have gone out as `0.12.2` and nothing would have objected.

## Which half of the "done when" this is

The finding offered two options: bump the version, or add a CI check that the tag being released is consistent with the conventional commits since the last one. This is the first — it is what is actually needed right now, and it is one line.

The check is the more durable fix and would prevent a recurrence rather than correcting this instance. I left it out deliberately: it is real machinery in `release.yml`, it is a judgement call how strict to make it, and it is a separate concern from getting today's number right. Happy to follow up if you want it.

## Verification

`git log --format='%s' v0.12.1..HEAD | grep -E '^[a-z]+(\(.+\))?!:'` → exactly one match, the 3.9 drop. `uv.lock` re-synced for the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)