### PR TITLE
refactor: split OptionResolver.tests into validation and resolution

### DIFF
--- a/src/pytest_alembic/plugin/plugin.py
+++ b/src/pytest_alembic/plugin/plugin.py
@@ -323,47 +323,55 @@ class OptionResolver:
         """The resolved tests in a stable order, so collection order is reproducible."""
         return sorted(self.tests(), key=lambda t: t.raw_name)
 
+    def _requested_names(self) -> list[str]:
+        """The names the options select, in collection order, with exclusions applied.
+
+        ``included_tests`` of ``None`` means "not specified", which selects every
+        non-experimental test; experimental ones are only ever selected by name, which
+        is why the two lists are walked separately rather than merged.
+
+        Names are returned whether or not they are recognised -- validating them is
+        :meth:`_unrecognised_names`'s job, and it needs to see them.
+        """
+        excluded = set(self.excluded_tests or [])
+
+        if self.included_tests is None:
+            included = [t.name for t in self.available_tests.values() if t.is_experimental is False]
+        else:
+            included = self.included_tests
+
+        return [
+            name
+            for group in (included, self.included_experimental_tests or [])
+            for name in group
+            if name not in excluded
+        ]
+
+    def _unrecognised_names(self, requested: list[str]) -> list[str]:
+        """Every option value which does not name a known test.
+
+        Both directions are checked -- excluding a test that does not exist is as much
+        a typo as including one -- and every offender is gathered rather than raised on
+        sight, so a typo in one option does not hide a typo in another.
+        """
+        candidates = [*set(self.excluded_tests or []), *requested]
+        return [name for name in candidates if name not in self.available_tests]
+
     def tests(self) -> list[PytestAlembicTest]:
         """Resolve the options into the selected tests.
-
-        Every unrecognised name is gathered before raising, so a typo in one option does
-        not hide a typo in another.
 
         Raises:
             ValueError: If any included or excluded name is not a known test.
         """
-        selected_tests = []
-        invalid_tests = []
+        requested = self._requested_names()
 
-        excluded_set = set(self.excluded_tests or [])
-        for excluded_test in excluded_set:
-            if excluded_test not in self.available_tests:
-                invalid_tests.append(excluded_test)
-
-        if self.included_tests is None:
-            included_tests = [
-                t.name for t in self.available_tests.values() if t.is_experimental is False
-            ]
-        else:
-            included_tests = self.included_tests
-
-        for test_group in [included_tests, self.included_experimental_tests or []]:
-            for included_test in test_group:
-                if included_test in excluded_set:
-                    continue
-
-                if included_test not in self.available_tests:
-                    invalid_tests.append(included_test)
-                    continue
-
-                selected_tests.append(included_test)
-
-        if invalid_tests:
-            invalid_str = ", ".join(sorted(invalid_tests))
+        unrecognised = self._unrecognised_names(requested)
+        if unrecognised:
+            invalid_str = ", ".join(sorted(unrecognised))
             message = f"The following tests were unrecognized: {invalid_str}"
             raise ValueError(message)
 
-        return [self.available_tests[t] for t in selected_tests]
+        return [self.available_tests[name] for name in requested]
 
 
 def parse_test_names(raw_test_names: str) -> set[str]:


### PR DESCRIPTION
Closes #198.

`OptionResolver.tests` was the only block in the package at C or worse — **C (14)**, against a package average of A (2.62) and every module at maintainability grade A. It was doing two jobs in one pass: *validating* that every included and excluded name is a known test, and *resolving* the selection. The `invalid_tests` accumulator threaded through both, which is where the branches came from.

## The split

- **`_requested_names()`** — applies the include/exclude options and returns the names to collect, in order. It returns names whether or not they are recognised, because validating them is the other method's job and it needs to see them.
- **`_unrecognised_names(requested)`** — the option values that do not name a known test, in both directions.
- **`tests()`** — the composition of the two: resolve, validate, raise or return.

## Behaviour is unchanged, including two details worth keeping

Both are easy to lose in a refactor like this, so stating them explicitly:

- **Unrecognised names are still gathered before raising**, not raised on sight — the existing docstring's reason being that "a typo in one option does not hide a typo in another". `test_include_specified_invalid` pins this by matching `"bar, foo"`, i.e. both offenders in one message.
- **Excluding a test that does not exist is still an error**, not a silently ignored no-op. `test_exclude_specified_invalid` pins that.

One thing that looks like a change and isn't: previously an invalid *included* name was appended to `invalid_tests` **and** skipped from `selected_tests`. Now it stays in `requested`. That is equivalent, because any unrecognised name raises before the selection is ever used.

## Result

```
$ uvx radon cc src -n C
(no output — no block at C or worse)

$ uvx radon cc src -a -s
115 blocks analyzed. Average complexity: A (2.58)
```

`OptionResolver.tests` goes C (14) → **A (3)**; the extracted `_requested_names` is B (9) and `_unrecognised_names` is A (4).

## Verification

- `uv run pytest tests/plugin src/pytest_alembic/plugin` → 26 passed. These cover `OptionResolver` directly.
- `uv run pytest tests/test_runner.py` → 41 passed. This is the integration path — `TestCollector.collect` calls `sorted_tests()` → `tests()`, so the example runs exercise the resolution end to end.
- `make lint` → clean on 34 modules.
- Coverage of the changed region: every line in `OptionResolver` is executed by `tests/plugin`. (The one line the plugin-only subset reports as missed, `:141`, is unrelated to this diff and needs `COVERAGE_PROCESS_START`, which the full `make test` sets.)

I ran the two relevant suites rather than the whole of `make test` — worth a full run in CI, which the PR will do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)