### PR TITLE
test: assert where the version table went, and record what makes the example suite fail

### DIFF
--- a/examples/test_version_table_schema/test_migrations.py
+++ b/examples/test_version_table_schema/test_migrations.py
@@ -1,0 +1,20 @@
+from sqlalchemy import text
+
+
+def test_version_table_lives_in_the_configured_schema(alembic_runner, alembic_engine):
+    """Assert alembic's bookkeeping table landed where `env.py` asked for it.
+
+    Every other check in this example passes whether or not `version_table_schema` was
+    honoured -- the migrations touch `foo`, not the version table, so ignoring the
+    option entirely would still leave a green run. This is the one assertion that
+    actually looks at where the version table went.
+    """
+    alembic_runner.migrate_up_to("heads")
+
+    query = text(
+        "SELECT table_schema FROM information_schema.tables WHERE table_name = 'alembic_version'"
+    )
+    with alembic_engine.connect() as conn:
+        schemas = sorted(row.table_schema for row in conn.execute(query))
+
+    assert schemas == ["version_table_schema"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -93,7 +93,12 @@ def test_multiple_schemata(pytester: pytest.Pytester) -> None:
 
 
 def test_schema_revision_data(pytester: pytest.Pytester) -> None:
-    """Assert that revision data handles schema names included in the table name."""
+    """Assert that revision data handles schema names included in the table name.
+
+    The assertion is inside migration ``bbbbbbbbbbbb``, which selects from ``meow.foo``
+    and checks it holds exactly the configured row. Breaking the ``"schema.table"``
+    parsing in ``ConnectionExecutor.table_insert`` turns this test red.
+    """
     run_pytest(pytester, passed=3)
 
 
@@ -207,7 +212,13 @@ def test_downgrade_leaves_no_trace_failure(pytester: pytest.Pytester) -> None:
 
 
 def test_minimum_downgrade_revision(pytester: pytest.Pytester) -> None:
-    """Assert the minimum_downgrade_revision config option is abided."""
+    """Assert the minimum_downgrade_revision config option is abided.
+
+    As with ``test_skip_revision``, the assertion is in the history: ``bbbbbbbbbbbb``'s
+    ``downgrade()`` raises ``ValueError``, and the configured floor is ``cccccccccccc``,
+    so a downgrade that walked past the floor would hit it. Neutering the option in
+    ``src/`` turns this test red.
+    """
     run_pytest(pytester, passed=5)
 
 
@@ -289,7 +300,13 @@ def test_generate_revision(pytester: pytest.Pytester) -> None:
 
 
 def test_skip_revision(pytester: pytest.Pytester) -> None:
-    """Assert a revision can be skipped through configuring the "skip_revisions" config."""
+    """Assert a revision can be skipped through configuring the "skip_revisions" config.
+
+    The assertion lives in the history rather than here: revision ``bbbbbbbbbbbb``'s
+    ``upgrade()`` raises unconditionally, so the built-in tests pass only if it was
+    stamped rather than run. That ``raise`` is load-bearing -- neutering
+    ``skip_revisions`` in ``src/`` turns this test red.
+    """
     run_pytest(pytester, passed=4)
 
 
@@ -299,12 +316,23 @@ def test_pytest_alembic_tests_path(pytester: pytest.Pytester) -> None:
 
 
 def test_version_table_schema(pytester: pytest.Pytester) -> None:
-    """Assert the setting the version_table_schema option functions correctly."""
-    run_pytest(pytester, passed=5)
+    """Assert the setting the version_table_schema option functions correctly.
+
+    The example carries its own `test_migrations.py` asserting *where* the version
+    table ended up, because nothing else here would notice: the migrations touch
+    `foo` rather than `alembic_version`, so the built-in tests pass whether or not
+    `env.py`'s `version_table_schema` was honoured.
+    """
+    run_pytest(pytester, passed=6)
 
 
 def test_branched_history_before_upgrade_data(pytester: pytest.Pytester) -> None:
-    """Assert branched upgrade data is only inserted once per migration."""
+    """Assert branched upgrade data is only inserted once per migration.
+
+    The assertion is the primary key: the configured row is ``{"id": 1}``, so inserting
+    it a second time raises rather than passing silently. Duplicating the
+    ``insert_into`` call in ``managed_upgrade`` turns this test red.
+    """
     run_pytest(pytester, passed=4)
 
 


### PR DESCRIPTION
Addresses #197 — but not as filed. **The finding was substantially wrong, and this PR is mostly the correction.**

## What #197 claimed

That the config-feature examples assert only "N tests passed", and would stay green if the feature were ignored entirely — naming `test_skip_revision`, `test_version_table_schema` and `test_schema_revision_data`.

## What mutation testing actually shows

I neutered each feature in `src/` and re-ran the corresponding example. Three of the four go red:

| mutation | example | result |
| --- | --- | --- |
| `skip_revisions` never matches | `test_skip_revision` | **RED** |
| `minimum_downgrade_revision` never matches | `test_minimum_downgrade_revision` | **RED** |
| `"schema.table"` parsing removed from `table_insert` | `test_schema_revision_data` | **RED** |
| `insert_into` called twice in `managed_upgrade` | `test_branched_history_before_upgrade_data` | **RED** |

The assertions were there all along. They live in the **migration bodies** and in **table constraints**, not in a `test_*.py`:

- `test_skip_revision` — revision `bbbbbbbbbbbb`'s `upgrade()` is a bare `raise`. It passes only if the revision was stamped rather than run.
- `test_minimum_downgrade_revision` — `bbbbbbbbbbbb`'s `downgrade()` raises `ValueError`, below the configured floor.
- `test_schema_revision_data` — migration `bbbbbbbbbbbb` does `SELECT * FROM meow.foo` and asserts it holds exactly the configured row.
- `test_branched_history_before_upgrade_data` — the row is `{"id": 1}`, so a second insert hits the primary key.

The original count only looked for `assert` in `test_*.py` files, which is precisely the mechanism these examples don't use. My error.

## The one real gap

`test_version_table_schema` is the exception, and it fails for the reason the finding gave. The migrations touch `foo`, never `alembic_version`, so nothing observed where the version table went. Removing `version_table_schema=` from that example's `env.py` left **all five checks green**.

It now carries a `test_migrations.py` asserting the version table is in the configured schema. With the option removed:

```
assert ['public'] == ['version_table_schema']
1 failed, 5 passed
```

— the new test red, the other five still green, which is the gap exactly. `run_pytest`'s expected count goes 5 → 6.

## Recording the mechanism

Since the *invisibility* of these assertions is what made the finding wrong, the four verified tests now say in their docstrings what makes them red. This is not decoration: those `raise` statements read as dead code, and deleting one as cleanup would silently disarm the test while leaving it green.

## Scope

I did not add assertions to examples that already have them. Writing a `test_*.py` for `test_skip_revision` to satisfy the letter of the finding would have added a second, weaker check of something the `raise` already covers.

## Verification

- `uv run pytest tests/test_runner.py` → 41 passed.
- `make lint` → clean on 34 modules.
- Every mutation above was run and reverted; `git diff --quiet` confirmed clean restoration each time.

## Suggested disposition for #197

Its score (test design quality 6 → 9) was based on a miscount and should be revised upward — the suite is better asserted than the finding said. I've left the issue open rather than closing it, since that is your call; happy to update it with this evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)