### PR TITLE
build: add pre-commit hooks and a root CONTRIBUTING.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,30 @@ jobs:
         # be reported into a log nobody reads.
         run: make audit-all
 
+  pre-commit:
+    # The hook config, as a gate. A `.pre-commit-config.yaml` no job invokes is a file
+    # rather than a gate -- it rots silently, and the first person to run
+    # `pre-commit install` finds out. Outside the test matrix for the reason `audit`
+    # and `docs-coverage` document below: the answer does not vary by matrix entry.
+    #
+    # This deliberately overlaps `make lint`, which is the check-only form of the same
+    # tools and gates every matrix entry. What is verified here is that the hooks
+    # themselves still resolve and run.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run the pre-commit hooks
+        run: uvx pre-commit run --all-files --show-diff-on-failure
+
   docs-coverage:
     # Docstring coverage. Outside the test matrix for the same reason the audit job
     # documents above: the answer is identical for every matrix entry, so running it

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# Local, pre-push feedback for checks CI already runs. What this adds is timing: `ruff
+# format` disagreeing shows up on `git commit` rather than after a push and a full
+# matrix run.
+#
+# Every hook is `repo: local` and goes through `uv run`, deliberately. The usual mirrors
+# (ruff-pre-commit, mirrors-mypy) carry their own `rev:`, which would give this repo a
+# second pin for a tool `uv.lock` already pins -- two versions drifting apart, so a hook
+# could pass here while the identical check fails in CI. Going through `uv run` means
+# both run the locked version, and adds no third-party code to the toolchain.
+#
+# `files:` matches `make lint`'s scope exactly. Widening it would start reporting on
+# files the project deliberately does not lint, `docs/source/conf.py` among them.
+default_install_hook_types: [pre-commit]
+
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        # Fixing rather than reporting: a hook exists to make the commit right, not to
+        # refuse it. `make lint` is the check-only form, and is what gates CI.
+        entry: uv run ruff check --fix --force-exclude
+        language: system
+        types_or: [python, pyi]
+        files: ^(src|tests|examples)/
+        require_serial: true
+
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format --force-exclude
+        language: system
+        types_or: [python, pyi]
+        files: ^(src|tests|examples)/
+        require_serial: true
+
+      - id: mypy
+        name: mypy
+        # Whole-tree rather than per-file: mypy needs imports to resolve, and
+        # [tool.mypy] applies to `src` and `tests` as a unit.
+        entry: uv run mypy src tests
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+The full guide lives in the documentation:
+**[Contributing](https://pytest-alembic.readthedocs.io/en/latest/contributing.html)**
+(source: [`docs/source/contributing.rst`](docs/source/contributing.rst)). This file is
+the short version, because GitHub shows it when you open an issue or a pull request and
+the rendered page is a click away at that moment.
+
+## What you need
+
+- [uv](https://docs.astral.sh/uv/), which manages the environment and the lockfile.
+- **Docker**, running. The test suite provisions a real postgres through
+  [pytest-mock-resources](https://github.com/schireson/pytest-mock-resources); without
+  it a large part of the suite cannot run.
+
+## Getting set up
+
+```bash
+make install                 # sync the package and its dev dependencies
+uvx pre-commit install       # run the linters on `git commit` (optional, recommended)
+```
+
+`make help` lists every target. The ones that gate a pull request:
+
+| Command | Checks |
+| --- | --- |
+| `make lint` | ruff (lint + format) and mypy |
+| `make test` | the suite, with a **100%** coverage floor |
+| `make docs-coverage` | docstring coverage, floor **100%** |
+| `make docs` | the sphinx build, at zero warnings (`-W`) |
+| `make audit` / `make audit-all` | known vulnerabilities |
+
+CI runs all of them, so running `make lint` and `make test` before pushing is the
+fastest way to a green pull request. `make format` applies what `make lint` only
+reports.
+
+## A note on the three 100% floors
+
+Coverage, docstring coverage and type annotations are each held at 100% rather than at
+a threshold below the measured value. That is deliberate: a floor beneath the real
+number lets a new untested line, undocumented symbol or unannotated function hide in
+the slack. It does mean a new function needs a test, a docstring and annotations in the
+same change — which is the point, not an accident.
+
+## Commits
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/);
+`CHANGELOG.md` is generated from them with [convco](https://convco.github.io/). Mark a
+breaking change with `!` (`chore!: …`), since that is what decides the next version.


### PR DESCRIPTION
Closes #202.

Both halves of this finding are direct file checks rather than inferences — `ls .pre-commit-config.yaml CONTRIBUTING.md` found neither — so unlike #197 and #199 there was nothing to re-verify. Every gate ran in CI and none ran locally, so the first signal that `ruff format` disagreed arrived after a push and a full matrix run.

## The hooks are all `repo: local`, on purpose

The obvious config would use the upstream mirrors, `ruff-pre-commit` and `mirrors-mypy`. Each carries its own `rev:` — which would give this repo **a second pin for a tool `uv.lock` already pins**. Two pins for one tool drift independently, and the failure mode is the bad one: a hook passes locally while the identical check fails in CI, or vice versa, and the contributor has no reason to suspect the versions differ.

Going through `uv run` means the hook and `make lint` run the same locked version by construction. It also adds no third-party code to the toolchain, which sits better with the repo's stance in #191 than introducing two new `rev:`-pinned repositories would.

## `files:` matching `make lint`'s scope is load-bearing

`^(src|tests|examples)/` is not tidiness — it is required. `docs/source/conf.py` has **four** ruff findings and is deliberately outside `make lint`'s `src tests examples`. An unscoped hook would fail on a file the project does not lint, and the natural "fix" would be to start linting a file the project chose not to.

## Why the hooks fix rather than report

`ruff check --fix` and `ruff format` write. A hook exists to make the commit right, not to refuse it, and `make format` is the existing operation that does exactly this. `make lint` remains the check-only form and is what gates CI.

## CI runs them

A config no job invokes is a file rather than a gate — it rots quietly, and the first person to run `pre-commit install` finds out. The job sits outside the matrix for the reason `audit` and `docs-coverage` already document.

It overlaps `make lint`, deliberately. What it verifies is that the *hooks* still resolve and run; the ~10s duplicated cost, once per push rather than 28 times, seemed the right trade against the config silently breaking.

## CONTRIBUTING.md

Short by design, pointing at the rendered contributing page. GitHub surfaces this file when someone opens an issue or a pull request, which is exactly when a page inside the sphinx build is hardest to find. It carries the prerequisites, the setup commands, the gate table, and a short note on why the three 100% floors are what they are.

## Verification

- `uvx pre-commit run --all-files` → all three hooks pass.
- Confirmed they actually bite: appending `x  =  1` to `tests/test_history.py` makes `ruff format` fail and rewrite it to `x = 1`.
- Confirmed the scope is what saves `conf.py`: it has 4 ruff findings and the hooks pass anyway.
- `make lint` → clean on 34 modules. `build.yml` parses; jobs are now `test, audit, pre-commit, docs-coverage, docs, finish`.

## One thing to adjust on merge order

CONTRIBUTING.md's gate table lists the targets that exist **on `main` today**. I removed the `make deps` row I had first written, because that target only exists on #204's branch. If #204 merges first, the table wants that row back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)