### PR TITLE
build: ship LICENSE inside the wheel and the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,14 @@ name = "pytest-alembic"
 version = "0.12.1"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [{ name = "Dan Cardin", email = "ddcardin@gmail.com" }]
-license = { text = "MIT" }
+# PEP 639: an SPDX expression plus the files it refers to. The table form
+# (`license = { text = "MIT" }`) is the pre-639 spelling and is rejected outright once
+# `license-files` is present -- "project.license must be an SPDX expression string" --
+# so the two move together rather than as a style choice. The effect on the artifacts is
+# that `LICENSE` is now packaged instead of the licence surviving only as a metadata
+# string with nothing behind it.
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["pytest", "sqlalchemy", "alembic", "migration", "revision"]
 classifiers = [
     "Framework :: Pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,6 @@ name = "pytest-alembic"
 version = "0.12.1"
 description = "A pytest plugin for verifying alembic migrations."
 authors = [{ name = "Dan Cardin", email = "ddcardin@gmail.com" }]
-# PEP 639: an SPDX expression plus the files it refers to. The table form
-# (`license = { text = "MIT" }`) is the pre-639 spelling and is rejected outright once
-# `license-files` is present -- "project.license must be an SPDX expression string" --
-# so the two move together rather than as a style choice. The effect on the artifacts is
-# that `LICENSE` is now packaged instead of the licence surviving only as a metadata
-# string with nothing behind it.
 license = "MIT"
 license-files = ["LICENSE"]
 keywords = ["pytest", "sqlalchemy", "alembic", "migration", "revision"]


### PR DESCRIPTION
Closes #213.

`LICENSE` sat at the repo root and was packaged into neither artifact, so the licence
reached users as a metadata string with nothing behind it:

```
$ tar -tzf dist/pytest_alembic-0.12.1.tar.gz | grep -i license
(no output)
$ unzip -l dist/pytest_alembic-0.12.1-py3-none-any.whl | grep -ci license
0
```

The wheel's `dist-info/` held `WHEEL`, `entry_points.txt`, `METADATA` and `RECORD`, and
`METADATA` carried only `License: MIT`. Downstream packagers and licence-audit tooling
read the artifact rather than the git tree, so what they saw was an MIT claim with
nothing supporting it.

## Why this is two lines rather than one

Adding `license-files` alone does not build. The uv backend rejects it:

```
error: Invalid project metadata
  Caused by: When `project.license-files` is defined, `project.license` must be
  an SPDX expression string
```

So `license = { text = "MIT" }` becomes `license = "MIT"` in the same change -- PEP 639's
spelling, where the table form is the pre-639 one. The two move together because the
backend requires it, not as a style preference. There are no `License ::` trove
classifiers to remove, which PEP 639 also forbids alongside a licence expression.

## Result

Both artifacts now carry the file:

```
sdist:  pytest_alembic-0.12.1/LICENSE
wheel:  pytest_alembic-0.12.1.dist-info/licenses/LICENSE   (1053 bytes)
```

and the metadata becomes:

```
Metadata-Version: 2.4
License-Expression: MIT
License-File: LICENSE
```

## The one thing with blast radius

`Metadata-Version` moves from 2.3 to 2.4, since 2.4 is what carries `License-Expression`.
Very old installers do not understand it, so this was checked rather than assumed:
installing the built wheel with **pip 26.2.1** into a **Python 3.10** environment
resolves, and `LICENSE` lands on disk under `dist-info/licenses/` rather than only inside
the archive.

If supporting installers older than PEP 639 matters more than shipping the licence text,
the alternative is to leave the metadata at 2.3 and accept that the artifacts carry no
licence file -- worth stating explicitly, since that is the trade this PR makes.

## Verification

| Gate | Result |
| --- | --- |
| `make lint` | pass -- ruff check, ruff format, mypy over 34 modules |
| `make deps` | pass |
| `make audit` | pass -- `--frozen` export resolves, lockfile in sync |
| `make test` | **150 passed**, coverage `889 stmts / 196 branches, 0 miss, 100%` |

Branched from `main` rather than from #216, so the two are independent and can merge in
either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
