### PR TITLE
test: assert None at base instead of a tautology

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -54,7 +54,7 @@ def test_previous_revision_base() -> None:
     alembic_history = AlembicHistory.parse(revision_map)
     result = alembic_history.previous_revision("base")
 
-    assert result is result
+    assert result is None
 
 
 def test_next_revision() -> None:


### PR DESCRIPTION
Fixes #210.

`tests/test_history.py::test_previous_revision_base` asserted a tautology:

```python
result = alembic_history.previous_revision("base")

assert result is result   # true for every possible value
```

`x is x` holds for anything — `None`, a string, a wrong revision — so the test passed
regardless of what `previous_revision` returned, and it is the only test covering the
`base` boundary.

The assertion is now `result is None`, which is:

- what the method's own docstring promises — *"or `None` at `base`"*;
- what the `AlembicHistory` class doctest already asserts (`previous_revision("base") is None` → `True`);
- what the sibling `test_next_revision_head` asserts at the other end of the history.

## Verification

The new assertion has teeth. Regressing the implementation so it clamps at zero
instead of falling off the front —

```python
return self.revisions_by_index.get(max(revision_index - 1, 0))
```

— makes the test fail, where before it passed:

```
>       assert result is None
E       AssertionError: assert 'base' is None
```

With the implementation restored, the full suite is green: **122 passed**.

One line, in one test file. No production code touched.
