### PR TITLE
chore: drop the pytest-asyncio test dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,26 +50,24 @@ jobs:
       matrix:
         include:
           # Sweep across python version sweep with the highest checked dependency version.
-          # Older pytest/asyncio versions are tested separately below on a single
-          # interpreter since we have no reason to believe interpreter-specific breakage
-          # would surface in those older versions but not in pytest 9 + asyncio 1.x,
+          # Older pytest versions are tested separately below on a single interpreter
+          # since we have no reason to believe interpreter-specific breakage would
+          # surface in those older versions but not in pytest 9,
           # but we **do** know that newer versions of dependencies may not support arbitrarily old
           # python versions.
-          - {python-version: "3.10", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.11", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.12", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.13", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.14", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.15", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.10", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.12", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.14", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.15", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
 
           # For older tool versions, we can just stick to a single python version, again, because we
           # have no reason to believe their pytest-alembic specifically impacts their compatibility.
-          - {python-version: "3.13", pytest-version: "7.0.0", pytest-asyncio-version: "0.16.0", sqlalchemy-version: "2.0.40"}
-
-          # pytest-asyncio 0.23.x pairs with pytest 8 (0.23 is incompatible with
-          # pytest 7's hook API and triggers filterwarnings=error on 3.14 via
-          # deprecated asyncio APIs).
-          - {python-version: "3.13", pytest-version: "8.3.5", pytest-asyncio-version: "0.23.0", sqlalchemy-version: "2.0.40"}
+          # 7.0.0 is the floor declared in [project.dependencies]; 8.3.5 covers the
+          # intervening major, whose hook API differs from both neighbours.
+          - {python-version: "3.13", pytest-version: "7.0.0", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.13", pytest-version: "8.3.5", sqlalchemy-version: "2.0.40"}
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -86,7 +84,6 @@ jobs:
         run: |
           uv pip install 'sqlalchemy~=${{ matrix.sqlalchemy-version }}'
           uv pip install 'pytest~=${{ matrix.pytest-version }}'
-          uv pip install 'pytest-asyncio~=${{ matrix.pytest-asyncio-version }}'
 
       - name: Run linters
         run: make lint
@@ -97,7 +94,7 @@ jobs:
       - name: Store test result artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-${{ matrix.pytest-asyncio-version }}-${{ matrix.sqlalchemy-version }}
+          name: coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-${{ matrix.sqlalchemy-version }}
           path: coverage.xml
 
       - name: Coveralls

--- a/docs/source/asyncio.rst
+++ b/docs/source/asyncio.rst
@@ -53,7 +53,7 @@ something like
 .. code-block:: python
 
    from sqlalchemy import create_engine
-   from sqlalchemy.ext.asyncio import create_engine_async, AsyncEngine
+   from sqlalchemy.ext.asyncio import create_async_engine, AsyncEngine
 
    @pytest.fixture
    def alembic_engine(...):
@@ -70,6 +70,16 @@ something like
    from pytest_mock_resources import create_postgres_fixture
 
    alembic_engine = create_postgres_fixture(async_=True)
+
+Note that ``pytest-alembic`` itself only cares that the fixture *yields* an
+:class:`~sqlalchemy.ext.asyncio.AsyncEngine`; it never needs to await your fixture. The
+two plain ``@pytest.fixture`` forms above therefore work with no extra plugins, and are
+the forms exercised by this project's own test suite.
+
+The ``pytest-mock-resources`` form is different: ``async_=True`` produces a genuine
+async fixture, so resolving it requires an async-fixture plugin (such as
+``pytest-asyncio``) in **your** project. That is a requirement of the fixture, not of
+``pytest-alembic``.
 
 
 A slightly more versatile setup

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -13,8 +13,8 @@ you will also need Docker running locally.
 Getting Setup
 -------------
 ``pytest-alembic`` supports Python 3.10 and above (see ``requires-python`` in
-``pyproject.toml``). CI exercises 3.10 through 3.13 against a matrix of ``pytest``,
-``pytest-asyncio`` and ``sqlalchemy`` versions.
+``pyproject.toml``). CI exercises 3.10 through 3.15 against a matrix of ``pytest`` and
+``sqlalchemy`` versions.
 
 Run :code:`make help` to list the common commands, but for some basic setup:
 

--- a/examples/test_async_sqlalchemy/conftest.py
+++ b/examples/test_async_sqlalchemy/conftest.py
@@ -1,19 +1,13 @@
 import pytest
-import pytest_asyncio
 from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy import create_engine
 from sqlalchemy.engine.url import URL
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 pg = create_postgres_fixture()
 
 
-try:
-    fixture = pytest_asyncio.fixture
-except AttributeError:
-    fixture = pytest.fixture
-
-
-@fixture
+@pytest.fixture
 def alembic_engine(pg):
     creds = pg.pmr_credentials
     url = URL.create(
@@ -24,4 +18,4 @@ def alembic_engine(pg):
         port=creds.port,
         database=creds.database,
     )
-    return create_async_engine(url)
+    return AsyncEngine(create_engine(url))

--- a/examples/test_async_sqlalchemy/setup.cfg
+++ b/examples/test_async_sqlalchemy/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-asyncio_mode = auto

--- a/examples/test_async_sqlalchemy_native/conftest.py
+++ b/examples/test_async_sqlalchemy_native/conftest.py
@@ -1,7 +1,23 @@
 import pytest
 from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy.engine.url import URL
+from sqlalchemy.ext.asyncio import create_async_engine
 
-alembic_engine = create_postgres_fixture(async_=True)
+pg = create_postgres_fixture()
+
+
+@pytest.fixture
+def alembic_engine(pg):
+    creds = pg.pmr_credentials
+    url = URL.create(
+        drivername="postgresql+asyncpg",
+        username=creds.username,
+        password=creds.password,
+        host=creds.host,
+        port=creds.port,
+        database=creds.database,
+    )
+    return create_async_engine(url)
 
 
 @pytest.fixture

--- a/examples/test_experimental_all_models_register_async/conftest.py
+++ b/examples/test_experimental_all_models_register_async/conftest.py
@@ -1,9 +1,25 @@
 import pytest
 from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy.engine.url import URL
+from sqlalchemy.ext.asyncio import create_async_engine
 
 import pytest_alembic.tests.experimental
 
-alembic_engine = create_postgres_fixture(async_=True)
+pg = create_postgres_fixture()
+
+
+@pytest.fixture
+def alembic_engine(pg):
+    creds = pg.pmr_credentials
+    url = URL.create(
+        drivername="postgresql+asyncpg",
+        username=creds.username,
+        password=creds.password,
+        host=creds.host,
+        port=creds.port,
+        database=creds.database,
+    )
+    return create_async_engine(url)
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,9 @@ dev = [
     "mypy>=1.11",
     "psycopg2-binary",
     "pytest>=8.3.2",
-    "pytest-asyncio",
     "pytest-mock-resources[docker]>=2.13.0",
     "ruff>=0.15.0",
     "sqlalchemy[asyncio]>=2.0.42",
-    "anyio",
 ]
 docs = ["myst-parser", "sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints", "sphinx-autobuild"]
 
@@ -133,7 +131,6 @@ parallel = true
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS"
 addopts = "--doctest-modules -vv --ff --strict-markers"
-asyncio_default_fixture_loop_scope = "function"
 pytest_alembic_exclude = 'up_down_consistency'
 norecursedirs = ".* build dist *.egg"
 pytester_example_dir = "examples"
@@ -145,7 +142,6 @@ filterwarnings = [
     "ignore:unclosed connection.*:ResourceWarning",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore:.*is deprecated and will be removed in Python 3.14.*:DeprecationWarning",
-    "ignore:.*asyncio_default_fixture_loop_scope.*:pytest.PytestDeprecationWarning",
 ]
 
 [tool.mypy]

--- a/uv.lock
+++ b/uv.lock
@@ -206,15 +206,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1437,7 +1428,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "anyio" },
     { name = "asyncpg" },
     { name = "coverage", extra = ["toml"] },
     { name = "deptry" },
@@ -1446,7 +1436,6 @@ dev = [
     { name = "mypy" },
     { name = "psycopg2-binary" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-mock-resources", extra = ["docker"] },
     { name = "ruff" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -1474,7 +1463,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "anyio" },
     { name = "asyncpg" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.4.4" },
     { name = "deptry", specifier = ">=0.20" },
@@ -1483,7 +1471,6 @@ dev = [
     { name = "mypy", specifier = ">=1.11" },
     { name = "psycopg2-binary" },
     { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-asyncio" },
     { name = "pytest-mock-resources", extras = ["docker"], specifier = ">=2.13.0" },
     { name = "ruff", specifier = ">=0.15.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.42" },
@@ -1494,20 +1481,6 @@ docs = [
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-rtd-theme" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pytest-alembic` itself never used `pytest-asyncio`. The shipped package depends on `pytest`, `alembic` and `sqlalchemy`, and drives async engines with a bare `asyncio.run` in `executor.run_task`; nothing under `src` imports the plugin. It was a dev dependency only.

## Three of its four usages were dead weight

- `examples/test_async_sqlalchemy` decorated a **synchronous** fixture with `pytest_asyncio.fixture`, and set `asyncio_mode = auto` in its `setup.cfg` for it. Nothing there was async.
- The root config set `asyncio_default_fixture_loop_scope`, and then added a `filterwarnings` ignore for the very deprecation warning that setting exists to silence.
- `anyio` sat in the dev group entirely unused.

## The one real usage did not need a plugin either

Two examples built `alembic_engine` from `create_postgres_fixture(async_=True)`, which is a genuine async fixture and so needs a plugin to resolve. But `pytest-alembic` never awaits your fixture — it only requires that one *yields* an `AsyncEngine`. A plain `@pytest.fixture` works, and then no plugin is needed at all.

So the two examples now cover the two synchronous forms `docs/source/asyncio.rst` already documents, one each. That also makes their test docstrings accurate for the first time:

| example | form | docstring claim |
|---|---|---|
| `test_async_sqlalchemy` | `AsyncEngine(create_engine(url))` | "manually adapted" ✔ |
| `test_async_sqlalchemy_native` | `create_async_engine(url)` | "native" ✔ |

Previously both built their engines natively, despite one claiming to cover the manually adapted case.

Since the pmr `async_=True` form is no longer exercised here, `asyncio.rst` now says plainly that it needs an async-fixture plugin in the reader's own project, and that the two plain-fixture forms need none. That requirement belongs to the fixture, not to `pytest-alembic`, and was previously unstated.

## CI

The `pytest-asyncio-version` dimension (`0.16.0` / `0.23.0` / `1.4.0`) is gone. It was never testing `pytest-alembic` against `pytest-asyncio` — no code path touches it — it was testing `pytest-mock-resources` against `pytest-asyncio`. The `pytest` 7.0.0 and 8.3.5 entries survive, now with a comment recording why those two: 7.0.0 is the floor declared in `[project.dependencies]`, and 8.3.5 covers the intervening major whose hook API differs from both neighbours.

`contributing.rst` also claimed CI exercises 3.10 through 3.13; the matrix is 3.10 through 3.15. Corrected in the same sentence.

## Verification

With both packages absent from the venv:

- `150 passed`
- coverage **100%**, so the floor in `[tool.coverage.report]` still holds
- `ruff check` / `ruff format --check` / `mypy` / `deptry` / `interrogate` clean
- `sphinx-build -W` succeeds
- the three async examples pass under `pytest~=7.0.0` and `pytest~=8.3.5`, the two older CI pins

Runtime is unchanged — 27.89s mean over three full-suite runs, against 28.00s before.

## A note on uv.lock

The lock diff is a pure 27-line deletion, hand-edited. A plain `uv lock` (uv 0.11.28) rewrites roughly 190 lines of unrelated resolution markers, and `uv lock --check` passes on the committed lock, so that rewrite is normalization rather than anything required. Worth a glance in case CI's uv version disagrees.

Also worth recording for anyone editing a lock by hand: `uv lock --check` did **not** catch a first attempt that accidentally stripped `anyio` from `starlette` and `watchfiles`' dependency lists. That was found by diffing the dependency graph, and the edit redone scoped to the `pytest-alembic` package block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
