### PR TITLE
ci: make the version matrix pin the versions it names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,26 +50,24 @@ jobs:
       matrix:
         include:
           # Sweep across python version sweep with the highest checked dependency version.
-          # Older pytest/asyncio versions are tested separately below on a single
-          # interpreter since we have no reason to believe interpreter-specific breakage
-          # would surface in those older versions but not in pytest 9 + asyncio 1.x,
+          # Older pytest versions are tested separately below on a single interpreter
+          # since we have no reason to believe interpreter-specific breakage would
+          # surface in those older versions but not in pytest 9,
           # but we **do** know that newer versions of dependencies may not support arbitrarily old
           # python versions.
-          - {python-version: "3.10", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.11", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.12", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.13", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.14", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.15", pytest-version: "9.1.1", pytest-asyncio-version: "1.4.0", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.10", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.12", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.14", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.15", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
 
           # For older tool versions, we can just stick to a single python version, again, because we
           # have no reason to believe their pytest-alembic specifically impacts their compatibility.
-          - {python-version: "3.13", pytest-version: "7.0.0", pytest-asyncio-version: "0.16.0", sqlalchemy-version: "2.0.40"}
-
-          # pytest-asyncio 0.23.x pairs with pytest 8 (0.23 is incompatible with
-          # pytest 7's hook API and triggers filterwarnings=error on 3.14 via
-          # deprecated asyncio APIs).
-          - {python-version: "3.13", pytest-version: "8.3.5", pytest-asyncio-version: "0.23.0", sqlalchemy-version: "2.0.40"}
+          # 7.0.0 is the floor declared in [project.dependencies]; 8.3.5 covers the
+          # intervening major, whose hook API differs from both neighbours.
+          - {python-version: "3.13", pytest-version: "7.0.0", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.13", pytest-version: "8.3.5", sqlalchemy-version: "2.0.40"}
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -86,7 +84,6 @@ jobs:
         run: |
           uv pip install 'sqlalchemy~=${{ matrix.sqlalchemy-version }}'
           uv pip install 'pytest~=${{ matrix.pytest-version }}'
-          uv pip install 'pytest-asyncio~=${{ matrix.pytest-asyncio-version }}'
 
       - name: Run linters
         run: make lint
@@ -97,7 +94,7 @@ jobs:
       - name: Store test result artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-${{ matrix.pytest-asyncio-version }}-${{ matrix.sqlalchemy-version }}
+          name: coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytest-version }}-${{ matrix.sqlalchemy-version }}
           path: coverage.xml
 
       - name: Coveralls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,27 +45,42 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     runs-on: ubuntu-latest
+    # `uv run` re-syncs the environment to uv.lock before executing, which silently
+    # reverts the pins installed below -- including from `make lint`, which runs first.
+    # This makes every `uv run` in the job use the environment as-is. `uv sync` in
+    # `make install` is unaffected, so the environment is still fully populated.
+    env:
+      UV_NO_SYNC: "1"
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Sweep across python version sweep with the highest checked dependency version.
-          # Older pytest versions are tested separately below on a single interpreter
+          # Every version here is applied with `==`, not `~=`, and the job runs with
+          # UV_NO_SYNC so `uv run` cannot revert it. Both matter: `~=2.0.40` means
+          # ">=2.0.40, ==2.0.*", which resolves to the newest 2.0.x and so pins nothing,
+          # and a plain `uv run` re-syncs to uv.lock and reinstalls the locked version.
+          # Read the `platform ... pytest-X.Y.Z` banner in the log to confirm what ran.
+
+          # Sweep across python versions at the highest checked dependency versions.
+          # Older tool versions are tested separately below on a single interpreter
           # since we have no reason to believe interpreter-specific breakage would
-          # surface in those older versions but not in pytest 9,
+          # surface in those older versions but not in the newest,
           # but we **do** know that newer versions of dependencies may not support arbitrarily old
           # python versions.
-          - {python-version: "3.10", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.12", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.14", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.15", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.10", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.12", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.14", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.15", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
 
           # For older tool versions, we can just stick to a single python version, again, because we
           # have no reason to believe their pytest-alembic specifically impacts their compatibility.
-          # 7.0.0 is the floor declared in [project.dependencies]; 8.3.5 covers the
-          # intervening major, whose hook API differs from both neighbours.
+          # pytest 7.0.0 is the floor declared in [project.dependencies]; 8.3.5 covers
+          # the intervening major, whose hook API differs from both neighbours.
+          # sqlalchemy 2.0.40 is the oldest checked version. It is paired only with 3.13
+          # because it publishes no cp314/cp315 wheels, and running the pure-python
+          # fallback there would test the fallback rather than the version.
           - {python-version: "3.13", pytest-version: "7.0.0", sqlalchemy-version: "2.0.40"}
           - {python-version: "3.13", pytest-version: "8.3.5", sqlalchemy-version: "2.0.40"}
 
@@ -82,8 +97,8 @@ jobs:
 
       - name: Install specific versions
         run: |
-          uv pip install 'sqlalchemy~=${{ matrix.sqlalchemy-version }}'
-          uv pip install 'pytest~=${{ matrix.pytest-version }}'
+          uv pip install 'sqlalchemy==${{ matrix.sqlalchemy-version }}'
+          uv pip install 'pytest==${{ matrix.pytest-version }}'
 
       - name: Run linters
         run: make lint

--- a/docs/source/asyncio.rst
+++ b/docs/source/asyncio.rst
@@ -53,7 +53,7 @@ something like
 .. code-block:: python
 
    from sqlalchemy import create_engine
-   from sqlalchemy.ext.asyncio import create_engine_async, AsyncEngine
+   from sqlalchemy.ext.asyncio import create_async_engine, AsyncEngine
 
    @pytest.fixture
    def alembic_engine(...):
@@ -70,6 +70,16 @@ something like
    from pytest_mock_resources import create_postgres_fixture
 
    alembic_engine = create_postgres_fixture(async_=True)
+
+Note that ``pytest-alembic`` itself only cares that the fixture *yields* an
+:class:`~sqlalchemy.ext.asyncio.AsyncEngine`; it never needs to await your fixture. The
+two plain ``@pytest.fixture`` forms above therefore work with no extra plugins, and are
+the forms exercised by this project's own test suite.
+
+The ``pytest-mock-resources`` form is different: ``async_=True`` produces a genuine
+async fixture, so resolving it requires an async-fixture plugin (such as
+``pytest-asyncio``) in **your** project. That is a requirement of the fixture, not of
+``pytest-alembic``.
 
 
 A slightly more versatile setup

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -13,8 +13,8 @@ you will also need Docker running locally.
 Getting Setup
 -------------
 ``pytest-alembic`` supports Python 3.10 and above (see ``requires-python`` in
-``pyproject.toml``). CI exercises 3.10 through 3.13 against a matrix of ``pytest``,
-``pytest-asyncio`` and ``sqlalchemy`` versions.
+``pyproject.toml``). CI exercises 3.10 through 3.15 against a matrix of ``pytest`` and
+``sqlalchemy`` versions.
 
 Run :code:`make help` to list the common commands, but for some basic setup:
 

--- a/examples/test_async_sqlalchemy/conftest.py
+++ b/examples/test_async_sqlalchemy/conftest.py
@@ -1,19 +1,13 @@
 import pytest
-import pytest_asyncio
 from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy import create_engine
 from sqlalchemy.engine.url import URL
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 pg = create_postgres_fixture()
 
 
-try:
-    fixture = pytest_asyncio.fixture
-except AttributeError:
-    fixture = pytest.fixture
-
-
-@fixture
+@pytest.fixture
 def alembic_engine(pg):
     creds = pg.pmr_credentials
     url = URL.create(
@@ -24,4 +18,4 @@ def alembic_engine(pg):
         port=creds.port,
         database=creds.database,
     )
-    return create_async_engine(url)
+    return AsyncEngine(create_engine(url))

--- a/examples/test_async_sqlalchemy/setup.cfg
+++ b/examples/test_async_sqlalchemy/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-asyncio_mode = auto

--- a/examples/test_async_sqlalchemy_native/conftest.py
+++ b/examples/test_async_sqlalchemy_native/conftest.py
@@ -1,7 +1,23 @@
 import pytest
 from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy.engine.url import URL
+from sqlalchemy.ext.asyncio import create_async_engine
 
-alembic_engine = create_postgres_fixture(async_=True)
+pg = create_postgres_fixture()
+
+
+@pytest.fixture
+def alembic_engine(pg):
+    creds = pg.pmr_credentials
+    url = URL.create(
+        drivername="postgresql+asyncpg",
+        username=creds.username,
+        password=creds.password,
+        host=creds.host,
+        port=creds.port,
+        database=creds.database,
+    )
+    return create_async_engine(url)
 
 
 @pytest.fixture

--- a/examples/test_experimental_all_models_register_async/conftest.py
+++ b/examples/test_experimental_all_models_register_async/conftest.py
@@ -1,9 +1,25 @@
 import pytest
 from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy.engine.url import URL
+from sqlalchemy.ext.asyncio import create_async_engine
 
 import pytest_alembic.tests.experimental
 
-alembic_engine = create_postgres_fixture(async_=True)
+pg = create_postgres_fixture()
+
+
+@pytest.fixture
+def alembic_engine(pg):
+    creds = pg.pmr_credentials
+    url = URL.create(
+        drivername="postgresql+asyncpg",
+        username=creds.username,
+        password=creds.password,
+        host=creds.host,
+        port=creds.port,
+        database=creds.database,
+    )
+    return create_async_engine(url)
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "asyncpg",
     "coverage[toml]>=6.4.4",
     "deptry>=0.20",
+    # What `sqlalchemy[asyncio]` pulls in, declared directly. The extra resolves to
+    # `greenlet>=1`, so it added nothing over this. sqlalchemy itself is a runtime
+    # dependency; CI pins the version under test explicitly.
     "greenlet>=3.0",
     "interrogate>=1.7",
     "mypy>=1.11",
@@ -39,7 +42,6 @@ dev = [
     "pytest>=8.3.2",
     "pytest-mock-resources[docker]>=2.13.0",
     "ruff>=0.15.0",
-    "sqlalchemy[asyncio]>=2.0.42",
 ]
 docs = ["myst-parser", "sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints", "sphinx-autobuild"]
 
@@ -52,8 +54,8 @@ skip_covered = true
 # lets a new untested path hide inside the slack.
 #
 # The previous floor of 93 was set because the CI matrix skipped the asyncio tests on
-# sqlalchemy versions without asyncio support. That reason is gone: the matrix pins a
-# single sqlalchemy (2.0.40), so no entry skips them any more.
+# sqlalchemy versions without asyncio support. That reason is gone: every matrix entry
+# pins a sqlalchemy 2.x, so `requires_asyncio_support` never skips.
 #
 # Each matrix entry enforces this on its own -- `make test` runs the report per job --
 # so what is excluded below has to be excluded for *every* entry, not just this one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,9 @@ dev = [
     "mypy>=1.11",
     "psycopg2-binary",
     "pytest>=8.3.2",
-    "pytest-asyncio",
     "pytest-mock-resources[docker]>=2.13.0",
     "ruff>=0.15.0",
     "sqlalchemy[asyncio]>=2.0.42",
-    "anyio",
 ]
 docs = ["myst-parser", "sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints", "sphinx-autobuild"]
 
@@ -133,7 +131,6 @@ parallel = true
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS"
 addopts = "--doctest-modules -vv --ff --strict-markers"
-asyncio_default_fixture_loop_scope = "function"
 pytest_alembic_exclude = 'up_down_consistency'
 norecursedirs = ".* build dist *.egg"
 pytester_example_dir = "examples"
@@ -145,7 +142,6 @@ filterwarnings = [
     "ignore:unclosed connection.*:ResourceWarning",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore:.*is deprecated and will be removed in Python 3.14.*:DeprecationWarning",
-    "ignore:.*asyncio_default_fixture_loop_scope.*:pytest.PytestDeprecationWarning",
 ]
 
 [tool.mypy]

--- a/uv.lock
+++ b/uv.lock
@@ -206,15 +206,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1437,7 +1428,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "anyio" },
     { name = "asyncpg" },
     { name = "coverage", extra = ["toml"] },
     { name = "deptry" },
@@ -1446,7 +1436,6 @@ dev = [
     { name = "mypy" },
     { name = "psycopg2-binary" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-mock-resources", extra = ["docker"] },
     { name = "ruff" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -1474,7 +1463,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "anyio" },
     { name = "asyncpg" },
     { name = "coverage", extras = ["toml"], specifier = ">=6.4.4" },
     { name = "deptry", specifier = ">=0.20" },
@@ -1483,7 +1471,6 @@ dev = [
     { name = "mypy", specifier = ">=1.11" },
     { name = "psycopg2-binary" },
     { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-asyncio" },
     { name = "pytest-mock-resources", extras = ["docker"], specifier = ">=2.13.0" },
     { name = "ruff", specifier = ">=0.15.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.42" },
@@ -1494,20 +1481,6 @@ docs = [
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-rtd-theme" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1438,7 +1438,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-mock-resources", extra = ["docker"] },
     { name = "ruff" },
-    { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 docs = [
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1473,7 +1472,6 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-mock-resources", extras = ["docker"], specifier = ">=2.13.0" },
     { name = "ruff", specifier = ">=0.15.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.42" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -1965,11 +1963,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
     { url = "https://files.pythonhosted.org/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
     { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
-]
-
-[package.optional-dependencies]
-asyncio = [
-    { name = "greenlet" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **Stacked on #219.** Until that merges, this PR shows both commits; only `ci: make the version matrix pin the versions it names` belongs to it. Review or merge #219 first.

The test matrix reported eight dependency combinations and ran two. Two independent causes, both silent.

## `~=` does not pin

`sqlalchemy~=2.0.40` means `>=2.0.40, ==2.0.*`, so it resolves to the newest 2.0.x. In the last run on #219, `uv sync` installed **2.0.52** and the `Install specific versions` step emitted **no install line at all** for sqlalchemy — 2.0.52 already satisfied the constraint. The `sqlalchemy-version` column has never varied anything since it was introduced.

Both pins are now `==`.

## `uv run` re-syncs, reverting the pin

`uv run` re-syncs the environment to `uv.lock` before executing, reinstalling the locked version over whatever `uv pip install` just placed. `make lint` runs before `make test`, so it reverted the pytest pin first — visible as `Uninstalled 1 package` under **Run linters**.

The job named `test (3.13, 7.0.0, 2.0.40)` reported this banner:

```
platform linux -- Python 3.13.15, pytest-9.1.1, pluggy-1.6.0
```

The job now sets `UV_NO_SYNC: "1"`. That affects `uv run` only — `uv sync` in `make install` still populates the environment, and local development is untouched. It is scoped to the `test` job deliberately: `deps` and `docs` run `uv run --group docs`, and those **do** need the implicit sync to install that group.

## Why the sweep rows move to sqlalchemy 2.0.52

Pinning `==2.0.40` across the sweep would have *lowered* what it covers. 2.0.52 is what those rows have actually been running, and it is what the comment above them already claims ("the highest checked dependency version").

2.0.40 stays on the two older-pytest rows as the oldest checked version, and only on 3.13 — it publishes no cp314/cp315 wheels, so on newer interpreters it installs the `py3-none-any` fallback, which would test the pure-python build rather than the version:

| version | cpython wheel tags |
|---|---|
| 2.0.40 | cp37–cp313 |
| 2.0.52 | cp38–cp314 |

So the column now genuinely varies — 2.0.52 on the sweep, 2.0.40 on the old-tool rows — instead of naming one value and testing another.

## The dev-group `sqlalchemy[asyncio]>=2.0.42`

Dropped. It duplicated the runtime `sqlalchemy` dependency in order to add an extra and a floor, and both parts were wrong:

- the extra resolves to exactly `greenlet>=1`, which `greenlet>=3.0` two lines above already covers more strongly
- the floor `>=2.0.42` **excluded** the 2.0.40 the matrix claims to test, so `uv sync` could never install it

`greenlet` keeps a short comment recording what the extra had been providing. The stale claim in the coverage comment that the matrix "pins a single sqlalchemy (2.0.40)" is corrected — every entry now pins some 2.x, so `requires_asyncio_support` never skips, which is what the 100% floor rests on.

## Verification

Simulated the real job order locally — `uv sync`, `uv pip install`, `make lint`, `make test` — for all three combinations. In each, the pins survive the lint step, the banner reports the pinned version, 150 tests pass, coverage stays at 100%:

| pins | after `make lint` | banner | result |
|---|---|---|---|
| `pytest==7.0.0` + `sqlalchemy==2.0.40` | pytest 7.0.0 / sqlalchemy 2.0.40 | `pytest-7.0.0` | 150 passed, 100% |
| `pytest==8.3.5` + `sqlalchemy==2.0.40` | pytest 8.3.5 / sqlalchemy 2.0.40 | `pytest-8.3.5` | 150 passed, 100% |
| `pytest==9.1.1` + `sqlalchemy==2.0.52` | pytest 9.1.1 / sqlalchemy 2.0.52 | `pytest-9.1.1` | 150 passed, 100% |

`ruff`, `mypy`, `deptry`, `interrogate`, `sphinx-build -W` and `pip-audit` all clean. mypy specifically re-checked under pytest 7.0.0 and 8.3.5, since `make lint` now runs against the pinned version rather than the locked one.

`uv.lock` is hand-edited to a 7-line deletion, because `uv lock` rewrites roughly 170 lines of unrelated resolution markers.

## Not addressed

The declared runtime floor is `sqlalchemy` unpinned, and `tests/__init__.py` still carries a `requires_asyncio_support` guard checking for 1.4. Nothing in CI tests sqlalchemy 1.4, so that guard can never be false and the real supported floor is undeclared. Picking an actual floor is a separate decision, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
