### PR TITLE
test: drop the unused requires_sqlalchemy_2 marker

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,10 +3,8 @@ import sqlalchemy
 
 sqlalchemy_version = getattr(sqlalchemy, "__version__", "1.3")
 supports_asyncio = sqlalchemy_version.startswith(("1.4", "2."))
-is_sqlalchemy_2 = sqlalchemy_version.startswith("2.")
 
 requires_asyncio_support = pytest.mark.skipif(
     not supports_asyncio,
     reason="Requires asyncio support",
 )
-requires_sqlalchemy_2 = pytest.mark.skipif(not is_sqlalchemy_2, reason="Requires v2")


### PR DESCRIPTION
Closes #211.

Taking the ending you approved:

> With the lower bound in place, if there's no test difference remaining that requires `requires_sqlalchemy_2` / `is_sqlalchemy_2`, then we can remove those symbols/markers.

## There is no remaining test difference

Verified at the declared floors rather than assumed:

```
$ uv sync --all-groups --resolution lowest-direct
$ uv run --all-groups --resolution lowest-direct python -c "..."
sqlalchemy 1.4.24 | alembic 1.9.0 | pytest 7.0.0

$ uv run --all-groups --resolution lowest-direct pytest src tests -q -rs
SKIPPED [1] tests/test_config.py:54: pyproject.toml is not supported in this version of alembic
149 passed, 1 skipped in 27.42s
```

The one skip gates on the **alembic** version, not sqlalchemy. Nothing in the suite
needs v2, so the marker had no test to be applied to.

## The lower bound is in place

`lowest-deps` (added in #221) runs the full suite at sqlalchemy 1.4.24 on every PR, so
1.4 support is gated by CI rather than by a skip marker. That is what makes the removal
safe, and it is the condition your comment named.

## What stays

`requires_asyncio_support`, `sqlalchemy_version` and `supports_asyncio` are all live —
the marker is applied at `tests/test_runner.py:264`, `:270` and `:280`, and the other two
feed it. Only the `requires_sqlalchemy_2` / `is_sqlalchemy_2` pair goes.

## One note on the matrix axis

Your earlier preference was to restore the `sqlalchemy` matrix axis instead. I did not add
one here, because on `main` a new row would not do what its name says: the pins use `~=`
(so `sqlalchemy~=1.4.54` resolves to the newest 1.4.x, which is fine) but `make lint` and
`make test` both go through `uv run`, which **re-syncs to `uv.lock` first** and reverts the
`uv pip install` pin. A `sqlalchemy-version: "1.4.54"` row would report 1.4 and run 2.0.52.
That was the subject of #220, which is closed. Happy to reopen that as a follow-up if you
want a real 1.4 column in the matrix on top of the `lowest-deps` gate — it needs
`UV_NO_SYNC: "1"` on the `test` job, not another matrix row.

## Verification

- `make lint` — ruff check, ruff format --check, mypy: clean
- `make test` — 150 passed, coverage **100%** (the floor is unaffected; `tests/` is not in
  `[tool.coverage.run] source`)
- `uv.lock` unchanged (the lowest-direct sync rewrote it locally; restored before committing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)