### PR TITLE
refactor: import AsyncEngine directly instead of guarding for sqlalchemy < 1.4

### DIFF
--- a/src/pytest_alembic/executor.py
+++ b/src/pytest_alembic/executor.py
@@ -20,6 +20,7 @@ from alembic.runtime.environment import EnvironmentContext
 from alembic.script.base import ScriptDirectory
 from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import Connectable, Connection, Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from pytest_alembic.config import Config
 
@@ -323,16 +324,7 @@ class ConnectionExecutor:
         even though all internals are synchronous. This is how alembic suggests
         running the migrations themselves, so this matches that style.
         """
-        # The user may not have sqlalchemy 1.4+, and therefore may not even be able to
-        # use async engines. The class is bound to a separate name rather than rebinding
-        # the import itself, so the sentinel and the class are not the same variable.
-        async_engine_cls: type | None = None
-        with contextlib.suppress(ImportError):
-            from sqlalchemy.ext.asyncio import AsyncEngine
-
-            async_engine_cls = AsyncEngine
-
-        if async_engine_cls and isinstance(self.connection, async_engine_cls):
+        if isinstance(self.connection, AsyncEngine):
             import asyncio
 
             async def run(engine: Any) -> Any:


### PR DESCRIPTION
Closes #226.

`run_task` reached `AsyncEngine` through a `contextlib.suppress(ImportError)` plus a
`type | None` sentinel, so a user on sqlalchemy 1.3 — which has no
`sqlalchemy.ext.asyncio` — could still import the module. Since #212 declared the floors,
`[project.dependencies]` requires `sqlalchemy>=1.4`, so that user cannot exist.

```diff
-        # The user may not have sqlalchemy 1.4+, and therefore may not even be able to
-        # use async engines. ...
-        async_engine_cls: type | None = None
-        with contextlib.suppress(ImportError):
-            from sqlalchemy.ext.asyncio import AsyncEngine
-
-            async_engine_cls = AsyncEngine
-
-        if async_engine_cls and isinstance(self.connection, async_engine_cls):
+        if isinstance(self.connection, AsyncEngine):
```

## Verified, not assumed — including the greenlet question

The obvious worry is that `sqlalchemy.ext.asyncio` needs greenlet, which is only in this
repo's **dev** group — so a module-level import could break sync-only installs. Tested at
four points across the declared range with greenlet **absent**:

| sqlalchemy | `from sqlalchemy.ext.asyncio import AsyncEngine`, no greenlet |
|---|---|
| 1.4.24 (the floor) | imports |
| 1.4.54 (last 1.4) | imports |
| 2.0.0 | imports |
| 2.0.52 (what CI runs) | imports |

greenlet is needed to *drive* an async engine, not to import the module — so the guard
was not doing that job either, and there is no reachable input that triggers it.

## Why a module-level import is safe here

`executor.py` already imports `from sqlalchemy import MetaData, Table` and
`from sqlalchemy.engine import Connectable, Connection, Engine` at module scope, so it
already hard-couples to sqlalchemy's module layout at import time. Adding
`sqlalchemy.ext.asyncio` is the same trust level as the imports beside it, on a public
path stable since 1.4.0. This is deliberately *not* the blast-radius case documented at
`plugin/plugin.py:249-262` — that one defers imports of **private alembic APIs**, which is
a different risk.

## The coverage angle

This is dead code the 100% ratchet could not see. `contextlib.suppress` is a context
manager rather than a branch, so no arc is recorded for the failure path, and the falsy
half of `async_engine_cls and …` is not a separately measured arc. A path that could never
execute was reported as covered.

## Verification

- `make lint` — ruff check, ruff format --check, mypy: clean
- `make test` — 150 passed, coverage **100%** (885 statements, three fewer)
- At the declared floors — **149 passed, 1 skipped** at sqlalchemy 1.4.24 / alembic 1.9.0 /
  pytest 7.0.0, which is what `lowest-deps` runs in CI
- `uv.lock` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)