### PR TITLE
build: declare the Python versions CI already gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,6 @@ authors = [{ name = "Dan Cardin", email = "ddcardin@gmail.com" }]
 license = "MIT"
 license-files = ["LICENSE"]
 keywords = ["pytest", "sqlalchemy", "alembic", "migration", "revision"]
-# One entry per interpreter the CI matrix in .github/workflows/build.yml actually
-# gates. Keep the two lists in step: `requires-python` decides what installs, but
-# these are what PyPI and installers *advertise*, so a version tested on every push
-# and missing here is support the project verifies without claiming.
 classifiers = [
     "Framework :: Pytest",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,18 @@ authors = [{ name = "Dan Cardin", email = "ddcardin@gmail.com" }]
 license = "MIT"
 license-files = ["LICENSE"]
 keywords = ["pytest", "sqlalchemy", "alembic", "migration", "revision"]
+# One entry per interpreter the CI matrix in .github/workflows/build.yml actually
+# gates. Keep the two lists in step: `requires-python` decides what installs, but
+# these are what PyPI and installers *advertise*, so a version tested on every push
+# and missing here is support the project verifies without claiming.
 classifiers = [
     "Framework :: Pytest",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 readme = "README.md"
 requires-python = ">=3.10,<4"


### PR DESCRIPTION
Closes #228.

The classifier list stopped at 3.13 while the CI matrix runs 3.10 → 3.15 and is green on
all six. `requires-python = ">=3.10,<4"` already lets 3.14 and 3.15 install; classifiers
are what PyPI and installers *advertise*. So the effect was support the project verifies
on every push without ever claiming it.

The same drift is visible on the published release, which predates the 3.9 drop:

```
$ curl -s https://pypi.org/pypi/pytest-alembic/json
latest on PyPI: 0.12.1
requires_python: <4,>=3.9
classifiers: ['... :: 3', '... :: 3.10', '... :: 3.11', '... :: 3.9']
```

## Verified in the built artifacts, not the source

```
$ uv build && twine check dist/*
Classifier: Programming Language :: Python :: 3.10 … 3.15   (all seven present)
Requires-Python: >=3.10, <4
Checking dist/pytest_alembic-0.12.1-py3-none-any.whl: PASSED
Checking dist/pytest_alembic-0.12.1.tar.gz: PASSED
```

Both new strings are registered trove classifiers, so nothing rejects them at upload.

A comment above the list now records that it tracks the CI matrix, so the next interpreter
added to one gets added to the other — the drift is the actual defect here, not the two
missing lines.

## One judgement call for you

**3.15 is currently `3.15.0rc1`** — that is literally what `test (3.15, …)` installs
(`Using CPython 3.15.0rc1` in the job log). So this advertises an interpreter that has not
had its final release. I included it because the matrix gates it on every push and the
issue's acceptance criterion was "match the interpreter range CI actually gates" — but if
you would rather advertise only final releases, drop the `3.15` line and this still closes
the 3.14 half. Happy either way; flagging it rather than deciding it silently.

## Verification

- `uv build` + `twine check` — both artifacts PASSED, metadata inspected directly from the wheel
- `make lint` — clean
- No source change, so the test suite is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)