### PR TITLE
docs: point intersphinx at SQLAlchemy 2.0, not 1.3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,11 +41,6 @@ html_sidebars = {"**": ["globaltoc.html", "relations.html", "sourcelink.html", "
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    # 2.0, not the 1.3 this pointed at for years. The project supports sqlalchemy
-    # >= 1.4 and the CI matrix runs 2.0.x, so the 1.3 inventory sent readers to
-    # documentation for a version pytest-alembic no longer works with -- and
-    # `sqlalchemy.ext.asyncio` does not exist in it at all, so the AsyncEngine
-    # reference on the asyncio page silently rendered as unlinked text.
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,12 @@ html_sidebars = {"**": ["globaltoc.html", "relations.html", "sourcelink.html", "
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "sqlalchemy": ("https://docs.sqlalchemy.org/en/13/", None),
+    # 2.0, not the 1.3 this pointed at for years. The project supports sqlalchemy
+    # >= 1.4 and the CI matrix runs 2.0.x, so the 1.3 inventory sent readers to
+    # documentation for a version pytest-alembic no longer works with -- and
+    # `sqlalchemy.ext.asyncio` does not exist in it at all, so the AsyncEngine
+    # reference on the asyncio page silently rendered as unlinked text.
+    "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
 }
 
 autoclass_content = "both"


### PR DESCRIPTION
Closes #227.

`docs/source/conf.py` loaded `https://docs.sqlalchemy.org/en/13/objects.inv` while the
project declares `sqlalchemy>=1.4` and the matrix runs 2.0.x. Two live cross-references
were affected, in opposite ways.

## Verified in the built HTML, not in the source

**Before:**

```
asyncio.html:     0 sqlalchemy links
custom_data.html: (in SQLAlchemy v1.3) -> /en/13/core/dml.html#...Insert.values
```

**After:**

```
asyncio.html:     (in SQLAlchemy v2.0) -> /en/20/orm/extensions/asyncio.html#...AsyncEngine
custom_data.html: (in SQLAlchemy v2.0) -> /en/20/core/dml.html#...Insert.values
```

- `custom_data.rst:60` resolved, to the **wrong version** — the rendered tooltip read
  `(in SQLAlchemy v1.3)`, sending readers to docs for a version pytest-alembic no longer
  supports.
- `asyncio.rst:75`'s `:class:`~sqlalchemy.ext.asyncio.AsyncEngine`` **did not resolve at
  all** — `sqlalchemy.ext.asyncio` does not exist in the 1.3 inventory, so it rendered as
  unlinked `<code>`. The page about asyncio was the one carrying the dead reference.

`en/20` rather than `en/latest` deliberately: a moving target changes the rendered links
without a commit.

## Why `-W` never caught this — and what it would cost to fix that

An unresolved python cross-reference is only reported when `nitpicky` is set, and it isn't
here, so sphinx silently drops the role and renders plain text. Turning it on is the real
hardening, but it does not belong in this PR: measured on this tree, `nitpicky = True`
produces **17** warnings and so fails the `-W` build immediately.

Several of those look like genuine defects worth their own change:

| warning | where |
|---|---|
| `alembic.config.Config` not found (×3) | `fixtures.py` docstrings — no alembic inventory is configured at all |
| `MigrationContext` not found | `api.rst:32` — unqualified |
| `create_alembic_fixture` not found | `running.rst:135` |
| `dict` / `list` as `:func:` (×4) | `custom_data.rst:54,57` — should be `:class:` |
| `RevisionSpec`, `pytest_alembic.MigrationContext` | `custom_data.rst:62`, `custom_tests.rst:27` |

Happy to open that as a follow-up issue, or fold it in here if you'd rather have it in one
go — I kept it out so this PR stays a one-line config fix with verified before/after.

## Verification

- `make docs` — `build succeeded` under `-W` from a clean tree (`docs/build/` removed first;
  the first run on the unmodified tree had reported `no targets are out of date` from cache)
- Both links confirmed by parsing the generated HTML, as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)