### PR TITLE
docs: fix the broken fixture example and the two placeholder assertions

### DIFF
--- a/src/pytest_alembic/plugin/fixtures.py
+++ b/src/pytest_alembic/plugin/fixtures.py
@@ -44,8 +44,8 @@ def create_alembic_fixture(
         ...     tests.test_upgrade_head(alembic)
         >>>
         >>> def test_specific_migration(alembic):
-        ...     alembic_runner.migrate_up_to('xxxxxxx')
-        ...     assert ...
+        ...     alembic.migrate_up_to('xxxxxxx')
+        ...     assert alembic.current == 'xxxxxxx'
 
         Config can also be supplied similarly to the :func:`alembic_config` fixture.
 
@@ -74,7 +74,7 @@ def alembic_runner(
     Examples:
         >>> def test_specific_migration(alembic_runner):
         ...     alembic_runner.migrate_up_to('xxxxxxx')
-        ...     assert ...
+        ...     assert alembic_runner.current == 'xxxxxxx'
     """
     config = Config.from_raw_config(alembic_config)
     with runner(config=config, engine=alembic_engine) as migration_context:


### PR DESCRIPTION
Addresses the substance of #230 — see the last section on why I don't think it closes the
issue as literally worded.

## A copy-paste bug that would have raised `NameError`

In `create_alembic_fixture`, the fixture is bound to `alembic`:

```python
>>> alembic = create_alembic_fixture()
>>> def test_specific_migration(alembic):
...     alembic_runner.migrate_up_to('xxxxxxx')   # <- undefined name
...     assert ...
```

The body called `alembic_runner` — which exists in the sibling `alembic_runner` fixture's
example this was copied from, but not here. Anyone copying this example got a `NameError`.

It passed every gate because a `>>> def` body is *compiled* and never *executed*, so the
name is never looked up. That is precisely the blind spot that makes an example **count** a
poor proxy for example **correctness**.

## Two `assert ...` placeholders

`assert ...` asserts the `Ellipsis` singleton, which is always truthy — so both examples
taught a no-op assertion as the shape of a custom test. Replaced with the claim the
surrounding prose actually makes, using the idiom `migrate_up_to`'s own docstring already
documents at `runner.py:310-312`:

```python
...     assert alembic_runner.current == 'xxxxxxx'
```

## Why this does not close #230 as worded

The finding said 41 of 60 examples carry no expected output, and asked for those outputs.
Having now inspected all 41 individually, **that figure overstates the remediable set**:

- **26** are `>>> def test_x(alembic_runner): ...` bodies. They document the shape a user
  writes, and need a live fixture and database to execute — they cannot carry a doctest
  output.
- **13** of the remaining 15 are imports and assignments (`>>> import pytest`,
  `>>> history = AlembicHistory.parse(...)`) — no output by definition.
- The docstrings that *do* return values already show and verify them. `AlembicHistory`,
  `history.parse`, `executor.metadata`, `Config.from_raw_config` and `parse_test_names` are
  exemplary: every claim is followed by a real assertion on real output.

So there is no meaningful "add the missing outputs" work left, and padding the remaining
examples would make the documentation *worse*. My metric conflated setup lines with
under-asserted ones — I'd suggest narrowing #230 to the mechanism gap below and closing the
counting part.

**The mechanism gap is real, though:** nothing checks names inside a `>>> def` body, which
is exactly why the bug above survived. A pyflakes pass over the doctest example bodies would
have caught it. Worth its own issue — say the word and I'll file it.

## Verification

- `make lint` — clean
- `make test` — 150 passed, coverage 100%
- bundled example checker — 60 examples, 3 README fences, **0 violations**, and no remaining
  `assert ...` anywhere in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)