### PR TITLE
test: make assert_has_test assert that the test ran

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -39,8 +39,21 @@ def run_pytest(
 
 
 def assert_has_test(result: pytest.HookRecorder, test_name: str) -> None:
+    """Assert exactly one test named `test_name` ran, whatever its outcome.
+
+    Presence and uniqueness are checked by the `matchreport` call itself: it raises
+    when the name matches no report, and again when it matches more than one. It has
+    no `None` return, which is why the assertion below is not `report is not None` --
+    that read like a check but could never fail.
+
+    What `matchreport` does not establish is that the test *ran*. A test that dies
+    during collection is reported too, as a `CollectReport`, which has no call phase;
+    asserting on the phase is what separates "collected" from "executed". The outcome
+    itself is deliberately not asserted here -- `run_pytest` already pins the exact
+    passed/skipped/failed counts, and one caller expects this test to have failed.
+    """
     report = result.matchreport(test_name)
-    assert report is not None
+    assert getattr(report, "when", None) == "call", report
 
 
 def assert_failed_test_has_content(result: pytest.HookRecorder, *, test: str, content: str) -> None:


### PR DESCRIPTION
Closes #229.

`assert report is not None` could never fail. `HookRecorder.matchreport` either returns a
report or raises `ValueError` — it raises when the name matches nothing, and again when it
matches more than one — so the `None` case does not exist. Same class as the
`assert result is result` tautology fixed in #218.

The helper was **not** inert, which is why this ranked below the other findings: presence
and uniqueness were genuinely checked, by `matchreport` raising. But that left the
assertion line doing nothing, and one real gap behind it — nothing distinguished a test
that **ran** from one merely **collected**. A test that dies during collection is still
reported, as a `CollectReport`, which has no call phase.

```python
    report = result.matchreport(test_name)
-   assert report is not None
+   assert getattr(report, "when", None) == "call", report
```

## Falsifiability checked, not assumed

The failure mode to avoid here is swapping one tautology for another, so I drove the
helper with stub reports:

| report | new assertion | old assertion |
|---|---|---|
| ran (`when="call"`) | passes | passes |
| collect-only (no `when`) | **fails** | passes |
| setup phase only | **fails** | passes |

The two rows where they differ are the coverage this adds.

## Why the outcome is not asserted

`assert report.passed` looks tempting and is wrong here. `run_pytest` already pins exact
`passed`/`skipped`/`failed` counts for every caller, and
`test_experimental_all_models_register_failure` (`tests/test_runner.py:157`) expects its
test to have *failed* — so asserting `passed` would break that call site. Verified against
all 8: `:122`, `:127`, `:132`, `:145`, `:151`, `:157`, `:183`, `:201`.

The docstring records both decisions, so the next reader doesn't re-derive why it isn't
`report is not None`.

## Verification

- `make lint` — clean
- `make test` — 150 passed, coverage 100%
- `tests/test_runner.py` alone — 41 passed, exercising every call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)