### PR TITLE
ci: make the version matrix pin the versions it names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,20 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     runs-on: ubuntu-latest
+
+    # `uv run` re-syncs the environment to uv.lock before executing, which reinstalled
+    # the locked versions over whatever the "Install specific versions" step below had
+    # just pinned. `make lint` runs first and reverted the pin before `make test` ever
+    # saw it, so every entry ran the locked pytest and sqlalchemy while its job name
+    # advertised something else. This affects `uv run` only -- `uv sync` in
+    # `make install` still populates the environment, and local development is
+    # untouched.
+    #
+    # Scoped to this job deliberately: `deps` and `docs` invoke `uv run --group <g>` and
+    # *depend* on that implicit sync to install the group, so they break with it set.
+    env:
+      UV_NO_SYNC: "1"
+
     strategy:
       fail-fast: false
       matrix:
@@ -55,17 +69,23 @@ jobs:
           # surface in those older versions but not in pytest 9,
           # but we **do** know that newer versions of dependencies may not support arbitrarily old
           # python versions.
-          - {python-version: "3.10", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.12", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.14", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
-          - {python-version: "3.15", pytest-version: "9.1.1", sqlalchemy-version: "2.0.40"}
+          - {python-version: "3.10", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.12", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.14", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
+          - {python-version: "3.15", pytest-version: "9.1.1", sqlalchemy-version: "2.0.52"}
 
           # For older tool versions, we can just stick to a single python version, again, because we
           # have no reason to believe their pytest-alembic specifically impacts their compatibility.
           # 7.0.0 is the floor declared in [project.dependencies]; 8.3.5 covers the
           # intervening major, whose hook API differs from both neighbours.
+          #
+          # sqlalchemy 2.0.40 is the oldest version checked, and it stays on 3.13 only:
+          # it publishes cp37-cp313 wheels, so on a newer interpreter pip would fall
+          # back to the `py3-none-any` build and the row would test the pure-python
+          # package rather than the version. The sweep above therefore names 2.0.52,
+          # which covers cp38-cp314 and is what those rows have in fact been running.
           - {python-version: "3.13", pytest-version: "7.0.0", sqlalchemy-version: "2.0.40"}
           - {python-version: "3.13", pytest-version: "8.3.5", sqlalchemy-version: "2.0.40"}
 
@@ -81,9 +101,13 @@ jobs:
         run: make install
 
       - name: Install specific versions
+        # `==`, not `~=`. `sqlalchemy~=2.0.40` means ">=2.0.40, ==2.0.*", which the
+        # already-installed newest 2.0.x satisfies -- so the step emitted no install
+        # line at all and the column never varied anything. A pin that logs nothing is
+        # the tell; a real one logs `- x==a` / `+ x==b`.
         run: |
-          uv pip install 'sqlalchemy~=${{ matrix.sqlalchemy-version }}'
-          uv pip install 'pytest~=${{ matrix.pytest-version }}'
+          uv pip install 'sqlalchemy==${{ matrix.sqlalchemy-version }}'
+          uv pip install 'pytest==${{ matrix.pytest-version }}'
 
       - name: Run linters
         run: make lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,17 +45,6 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     runs-on: ubuntu-latest
-
-    # `uv run` re-syncs the environment to uv.lock before executing, which reinstalled
-    # the locked versions over whatever the "Install specific versions" step below had
-    # just pinned. `make lint` runs first and reverted the pin before `make test` ever
-    # saw it, so every entry ran the locked pytest and sqlalchemy while its job name
-    # advertised something else. This affects `uv run` only -- `uv sync` in
-    # `make install` still populates the environment, and local development is
-    # untouched.
-    #
-    # Scoped to this job deliberately: `deps` and `docs` invoke `uv run --group <g>` and
-    # *depend* on that implicit sync to install the group, so they break with it set.
     env:
       UV_NO_SYNC: "1"
 
@@ -80,12 +69,6 @@ jobs:
           # have no reason to believe their pytest-alembic specifically impacts their compatibility.
           # 7.0.0 is the floor declared in [project.dependencies]; 8.3.5 covers the
           # intervening major, whose hook API differs from both neighbours.
-          #
-          # sqlalchemy 2.0.40 is the oldest version checked, and it stays on 3.13 only:
-          # it publishes cp37-cp313 wheels, so on a newer interpreter pip would fall
-          # back to the `py3-none-any` build and the row would test the pure-python
-          # package rather than the version. The sweep above therefore names 2.0.52,
-          # which covers cp38-cp314 and is what those rows have in fact been running.
           - {python-version: "3.13", pytest-version: "7.0.0", sqlalchemy-version: "2.0.40"}
           - {python-version: "3.13", pytest-version: "8.3.5", sqlalchemy-version: "2.0.40"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,9 @@ skip_covered = true
 # lets a new untested path hide inside the slack.
 #
 # The previous floor of 93 was set because the CI matrix skipped the asyncio tests on
-# sqlalchemy versions without asyncio support. That reason is gone: the matrix pins a
-# single sqlalchemy (2.0.40), so no entry skips them any more.
+# sqlalchemy versions without asyncio support. That reason is gone: every matrix entry
+# pins some 2.x (2.0.52 across the python sweep, 2.0.40 on the older-pytest rows), so
+# `requires_asyncio_support` never skips and no entry drops those tests.
 #
 # Each matrix entry enforces this on its own -- `make test` runs the report per job --
 # so what is excluded below has to be excluded for *every* entry, not just this one.


### PR DESCRIPTION
Closes #225.

The matrix reported eight dependency combinations and effectively ran two. Two
independent causes, both silent.

## `~=` does not pin

`sqlalchemy~=2.0.40` means `>=2.0.40, ==2.0.*`, which the already-installed newest 2.0.x
satisfies — so the step emitted **no sqlalchemy install line at all**, and that column has
never varied anything since it was introduced. A pin that logs nothing is the tell; a real
one logs `- x==a` / `+ x==b`. Both pins are now `==`.

## `uv run` re-syncs, reverting the pin

`uv run` re-syncs to `uv.lock` before executing. `make lint` runs before `make test`, so it
reverted the pytest pin before the suite ever saw it. From the run on `main` at `7638580`,
job `test (3.13, 7.0.0, 2.0.40)`:

```
+ pytest==9.1.1                                # uv sync
+ sqlalchemy==2.0.52                           # uv sync -- not 2.0.40
- pytest==9.1.1 / + pytest==7.0.1              # the pin, applied
Uninstalled 1 package / Installed 1 package    # make lint's uv run, reverting it
platform linux -- Python 3.13.15, pytest-9.1.1, pluggy-1.6.0
```

`test (3.13, 8.3.5, 2.0.40)` was identical. Since both varying rows sit on 3.13 — which the
sweep already covers — **two of the eight rows were exact duplicates of a third**.

`UV_NO_SYNC: "1"` is scoped to the `test` job deliberately: `deps` and `docs` run
`uv run --group <g>` and *depend* on that implicit sync to install the group.

## Verified locally by simulating the job order

```
uv pip install 'sqlalchemy==2.0.40' -> - sqlalchemy==2.0.52 / + sqlalchemy==2.0.40
uv pip install 'pytest==7.0.0'      -> - pytest==9.1.1      / + pytest==7.0.0

UV_NO_SYNC=1 uv run ... -> pytest 7.0.0 | sqlalchemy 2.0.40   (pins hold)
uv run ...              -> pytest 9.1.1 | sqlalchemy 2.0.52   (reverted)
```

**A pin that starts working can expose a real incompatibility**, so I ran the suite at each
newly-reachable combination on Python 3.13 rather than assuming green:

| pinned | banner | result |
|---|---|---|
| pytest 7.0.0 + sqlalchemy 2.0.40 | `pytest-7.0.0` | 150 passed |
| pytest 8.3.5 + sqlalchemy 2.0.40 | `pytest-8.3.5` | 150 passed |

`make lint` — ruff **and mypy** — is also clean under the pinned pytest 7.0.0, which is the
other thing that had never actually run.

## Why the sweep rows move to sqlalchemy 2.0.52

Pinning `==2.0.40` across the sweep would *lower* what it covers: 2.0.52 is what those rows
have in fact been running, and what the comment above them already claims. Wheel coverage,
checked against PyPI:

| version | cpython wheels |
|---|---|
| 2.0.40 | cp37–cp313 |
| 2.0.52 | cp38–cp314 |

So 2.0.40 stays on the 3.13 rows only — on 3.14/3.15 it would install the `py3-none-any`
fallback and test the pure-python build rather than the version.

The stale claim in `[tool.coverage.report]` that the matrix "pins a single sqlalchemy
(2.0.40)" is corrected: every entry pins some 2.x, so `requires_asyncio_support` never
skips, which is what the 100% floor rests on.

## Note

This is the mechanism from the closed #220, rebased onto current `main` and re-verified
from scratch. #221 landed the dependency floors and the `lowest-deps` gate, but not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)