### PR TITLE
ci: run the database-free tests on Windows and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,46 @@ jobs:
         # Not `make test`: that runs under coverage against the 100% floor.
         run: uv run --all-groups --resolution lowest-direct pytest src tests -q
 
+  cross-platform:
+    # Every other job here is `ubuntu-latest`, which left the one piece of explicitly
+    # platform-dependent reasoning in the package unexecuted: `get_bare_import_tableset`
+    # spawns `sys.executable` rather than PATH's `python`, and the comment at
+    # src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py:151-158
+    # justifies that specifically for Windows, "where [PATH's python] is frequently not
+    # an interpreter at all". Nothing verified it there.
+    #
+    # This job carries no postgres service, because GitHub supports service containers on
+    # Linux runners only. It therefore deselects the tests that need a real database via
+    # the `postgres` marker that tests/conftest.py derives -- 133 of 150 tests remain, and
+    # the Linux matrix above still runs all 150.
+    #
+    # Not `make test`, for two reasons. The first is the one `lowest-deps` gives below:
+    # that target runs under coverage against the 100% floor, which a deliberate subset
+    # cannot meet. The second is that the Makefile's recipes are POSIX shell -- `make test`
+    # sets its environment with `VAR=value cmd` -- so it is not portable to a Windows
+    # runner. `uv sync` and `uv run` are, which is why this job goes to them directly
+    # rather than through the front door the other jobs use.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run the tests that need no database
+        run: uv run pytest src tests -m "not postgres" -q
+
   docs:
     # The documentation build, as a gate. Outside the test matrix for the same
     # reason `audit` and `docs-coverage` document above: the .rst sources do not

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,24 +223,9 @@ jobs:
         run: uv run --all-groups --resolution lowest-direct pytest src tests -q
 
   cross-platform:
-    # Every other job here is `ubuntu-latest`, which left the one piece of explicitly
-    # platform-dependent reasoning in the package unexecuted: `get_bare_import_tableset`
-    # spawns `sys.executable` rather than PATH's `python`, and the comment at
-    # src/pytest_alembic/tests/experimental/all_models_register_on_metadata.py:151-158
-    # justifies that specifically for Windows, "where [PATH's python] is frequently not
-    # an interpreter at all". Nothing verified it there.
-    #
-    # This job carries no postgres service, because GitHub supports service containers on
-    # Linux runners only. It therefore deselects the tests that need a real database via
-    # the `postgres` marker that tests/conftest.py derives -- 133 of 150 tests remain, and
-    # the Linux matrix above still runs all 150.
-    #
-    # Not `make test`, for two reasons. The first is the one `lowest-deps` gives below:
-    # that target runs under coverage against the 100% floor, which a deliberate subset
-    # cannot meet. The second is that the Makefile's recipes are POSIX shell -- `make test`
-    # sets its environment with `VAR=value cmd` -- so it is not portable to a Windows
-    # runner. `uv sync` and `uv run` are, which is why this job goes to them directly
-    # rather than through the front door the other jobs use.
+    # We have a couple of potentially OS dependent code paths (path manipulation and
+    # subprocess calls). Our reliance on the postgres service for tests is incompatible with
+    # macos/windows, so we instead just run the test subsets which do not rely on a database.
     strategy:
       fail-fast: false
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,13 @@ addopts = "--doctest-modules -vv --ff --strict-markers"
 pytest_alembic_exclude = 'up_down_consistency'
 norecursedirs = ".* build dist *.egg"
 pytester_example_dir = "examples"
+# Applied automatically by `pytest_collection_modifyitems` in tests/conftest.py -- never
+# by hand, so it cannot drift out of step with what the examples actually use. It exists
+# so the non-Linux CI job can deselect the tests that need a real postgres: GitHub
+# supports service containers on Linux runners only.
+markers = [
+    "postgres: needs a reachable postgres; deselected on runners that have none",
+]
 filterwarnings = [
     "error",
     "default:.*which short-circuited the downgrade operation and may have passed the test.*:UserWarning",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,47 @@
+from pathlib import Path
+
+import pytest
 from pytest_mock_resources import create_postgres_fixture
 
 pytest_plugins = "pytester"
 
 db = create_postgres_fixture()
+
+EXAMPLES = Path(__file__).parent.parent / "examples"
+
+
+def _needs_postgres(item: pytest.Item) -> bool:
+    """Whether `item` can only run against a real postgres.
+
+    Two ways a test can need one, and neither is visible from the test body alone:
+
+    - it requests a `create_postgres_fixture` fixture directly (`db`, `pg`);
+    - it drives one of the `examples/` projects through `pytester`, and *that* project's
+      `conftest.py` overrides `alembic_engine` with a postgres engine. The default
+      `alembic_engine` is in-memory sqlite, so most examples need nothing.
+
+    The second case is derived from the example directory rather than listed, because a
+    hand-written list would silently rot the moment an example changed backend. The
+    directory is found by `pytester`'s own convention -- `pytester_example_dir` plus the
+    test name -- which is what `copy_example()` resolves.
+    """
+    if {"db", "pg"} & set(getattr(item, "fixturenames", ())):
+        return True
+
+    example = EXAMPLES / item.name
+    return example.is_dir() and any(
+        "postgres" in conftest.read_text() for conftest in example.rglob("conftest.py")
+    )
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Mark the tests that need a reachable postgres.
+
+    GitHub Actions supports service containers on Linux runners only, so the Windows and
+    macOS job has no database and deselects these with `-m "not postgres"`. Marking is
+    additive: nothing is skipped or deselected here, so the Linux matrix keeps running
+    the whole suite and the 100% coverage floor still applies to it.
+    """
+    for item in items:
+        if _needs_postgres(item):
+            item.add_marker(pytest.mark.postgres)


### PR DESCRIPTION
Closes #231.

> **Stacked on #239.** Both change the same workflow, so this PR shows both commits; only
> `ci: run the database-free tests on Windows and macOS` belongs to it. Review or merge
> #239 first.

All 10 jobs across both workflows were `ubuntu-latest`. That left the one piece of
explicitly platform-dependent reasoning in the package unexecuted: `get_bare_import_tableset`
spawns `sys.executable` rather than PATH's `python`, and the comment at
`all_models_register_on_metadata.py:151-158` justifies that **specifically for Windows**,
"where [PATH's python] is frequently not an interpreter at all". Nothing ever ran it there.

## The postgres constraint

GitHub supports service containers on **Linux runners only**, so the `postgres` service the
`test` job relies on cannot exist on a Windows or macOS runner. The database-dependent tests
are therefore deselected — and the marker that does it is **derived, not hand-written**.

`tests/conftest.py` marks an item `postgres` when it either:

- requests a `create_postgres_fixture` fixture directly (`db`, `pg`), or
- drives an `examples/` project whose own `conftest.py` overrides `alembic_engine` with
  postgres — resolved by pytester's own `pytester_example_dir` + test-name convention.

The default `alembic_engine` is in-memory sqlite, so most examples need nothing. Deriving it
matters: a hand-written list would rot silently the first time an example changed backend.

```
$ pytest src tests -m "postgres"     --collect-only  ->  17/150 collected
$ pytest src tests -m "not postgres" --collect-only  -> 133/150 collected
```

**Marking is additive.** Nothing is skipped or deselected in this repo's own runs, so the
Linux matrix still executes all 150 tests and the 100% coverage floor still applies to it
unchanged — verified: `make test` → 150 passed, coverage 100%.

## Not `make test`, for two reasons

The first is the one `lowest-deps` already gives: it runs under coverage against the 100%
floor, which a deliberate subset cannot meet. The second is portability — the Makefile's
recipes are POSIX shell (`make test` sets its environment with `VAR=value cmd`), so it does
not run on a Windows runner. `uv sync` and `uv run` do, which is why this job goes to them
directly rather than through the front door the other jobs use.

## What is verified, and what this job exists to find out

**macOS is verified locally** — I'm on darwin: the 133-test subset passes in 3.1s.

**Windows is not verified.** There is no Windows machine here, which is precisely why the
gap existed. My evidence that the subset needs no database is the enumeration above (those
are the only two routes by which a postgres engine can reach a test) plus the runtime split:
3.1s for the 133 against 29.7s for the 17. I tried pointing pmr at a dead port as a negative
control and it was not one — with docker available, pmr provisions its own container
regardless — so I am not claiming a proof I do not have.

**The job is the proof.** `fail-fast: false` means the macOS leg still reports if Windows is
red. If Windows *is* red, that is a real finding rather than a broken PR, and the answer is
the other half of #231: state the supported platforms explicitly so the gap becomes a
recorded decision instead of an omission. Happy to take it that way if that is what CI says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)