### PR TITLE
ci: gate the ends of the sqlalchemy range, not just its floor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,18 @@ jobs:
           - {python-version: "3.13", pytest-version: "7.0.0", sqlalchemy-version: "2.0.40"}
           - {python-version: "3.13", pytest-version: "8.3.5", sqlalchemy-version: "2.0.40"}
 
+          # The sqlalchemy range, for the same reason and by the same logic. `lowest-deps`
+          # covers the 1.4 floor and the rows above cover two adjacent 2.0 patches, which
+          # left the end of the 1.4 series and the 2.0.0 boundary gated by nothing --
+          # and the bug fixed in #221 (`AsyncConnection.commit` absent before 2.0)
+          # reproduced on *every* 1.4 release and on no 2.x release.
+          #
+          # 2.0.0 is on 3.11, not 3.13, deliberately: it does not import on 3.13, failing
+          # in `SQLCoreOperations` because `__firstlineno__` and `__static_attributes__`
+          # are new in 3.13 and 2.0.0's `TypingOnly` assertion predates them.
+          - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "1.4.54"}
+          - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.0"}
+
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,13 +74,7 @@ jobs:
 
           # The sqlalchemy range, for the same reason and by the same logic. `lowest-deps`
           # covers the 1.4 floor and the rows above cover two adjacent 2.0 patches, which
-          # left the end of the 1.4 series and the 2.0.0 boundary gated by nothing --
-          # and the bug fixed in #221 (`AsyncConnection.commit` absent before 2.0)
-          # reproduced on *every* 1.4 release and on no 2.x release.
-          #
-          # 2.0.0 is on 3.11, not 3.13, deliberately: it does not import on 3.13, failing
-          # in `SQLCoreOperations` because `__firstlineno__` and `__static_attributes__`
-          # are new in 3.13 and 2.0.0's `TypingOnly` assertion predates them.
+          # left the end of the 1.4 series and the 2.0.0 boundary gated by nothing.
           - {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "1.4.54"}
           - {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.0"}
 


### PR DESCRIPTION
Closes #244.

The `test` matrix named two sqlalchemy versions across all eight rows — `2.0.40` and
`2.0.52`, two adjacent patch releases — and `lowest-deps` added the `1.4.24` floor. So of
the `sqlalchemy>=1.4` range this project declares, CI gated one point of 1.4 and two
neighbouring points of 2.0.

That is thin in a specific way. The bug fixed in #221 (`AsyncConnection.commit` absent
before 2.0) reproduced on *every* 1.4 release and on no 2.x release, and its commit message
claims `1.4.24`, `1.4.54`, `2.0.0` and `2.0.52` all pass — on the strength of a manual run
that nothing repeated. A 1.4-only regression would have been caught only if it also
reproduced at `1.4.24`.

Two rows added:

```yaml
- {python-version: "3.13", pytest-version: "9.1.1", sqlalchemy-version: "1.4.54"}
- {python-version: "3.11", pytest-version: "9.1.1", sqlalchemy-version: "2.0.0"}
```

### Both rows were run locally before being added

Simulated in CI step order — `make install`, `uv pip install 'sqlalchemy==X'`, `make lint`,
`make test` — with `UV_NO_SYNC=1` and the postgres service available, so the counts include
the 17 database-backed tests rather than only the deselected subset:

| Row | Result |
| --- | --- |
| `1.4.54` / Python 3.13 | 150 passed; `mypy src tests` clean over 34 files; `ruff check` and `ruff format --check` clean |
| `2.0.0` / Python 3.11 | 150 passed |

### Why `2.0.0` is on 3.11 and not 3.13

It does not import on 3.13 at all — before any test runs:

```
AssertionError: Class <class 'sqlalchemy.sql.elements.SQLCoreOperations'> directly inherits
TypingOnly but has additional attributes {'__firstlineno__', '__static_attributes__'}
```

`__firstlineno__` and `__static_attributes__` are new in Python 3.13, and 2.0.0's
`TypingOnly` assertion predates them. The comment in the workflow records this so the row
is not "tidied" onto 3.13 later.

The declared range is now gated at `1.4.24`, `1.4.54`, `2.0.0`, `2.0.40`, `2.0.52` — every
version #221 claims by hand.
