### PR TITLE
docs: record why MigrationContext is one class, not two

### DIFF
--- a/src/pytest_alembic/runner.py
+++ b/src/pytest_alembic/runner.py
@@ -65,6 +65,20 @@ def runner(config: "Config", engine: Connectable | None = None) -> Iterator["Mig
     yield migration_context
 
 
+# On this module's size, which is deliberate. `runner.py` is the largest module in the
+# package and the most imported one, and `MigrationContext` below carries both the
+# migration verbs (`migrate_up_one`, `migrate_down_to`, `roundtrip_next_revision`) and the
+# history/state accessors (`current`, `heads`, `table_at_revision`, `insert_into`). Read as
+# a class in isolation, that is two responsibilities and an obvious split.
+#
+# It is one class because it is *the* documented public surface: the object
+# `alembic_runner` yields, and the receiver of every call in every example in the docs.
+# Splitting it would rename or re-home names that users have written tests against, for no
+# defect -- the metrics are healthy (no block above `B`, maintainability index `A`), so the
+# split would buy a tidier graph at the cost of an API break.
+#
+# If a genuine reason to split arrives, keep the public names on this class and delegate,
+# rather than asking callers to reach for a second object.
 @dataclass
 class MigrationContext:
     """Within a given environment/execution context, executes alembic commands.

--- a/src/pytest_alembic/runner.py
+++ b/src/pytest_alembic/runner.py
@@ -65,20 +65,9 @@ def runner(config: "Config", engine: Connectable | None = None) -> Iterator["Mig
     yield migration_context
 
 
-# On this module's size, which is deliberate. `runner.py` is the largest module in the
-# package and the most imported one, and `MigrationContext` below carries both the
-# migration verbs (`migrate_up_one`, `migrate_down_to`, `roundtrip_next_revision`) and the
-# history/state accessors (`current`, `heads`, `table_at_revision`, `insert_into`). Read as
-# a class in isolation, that is two responsibilities and an obvious split.
-#
-# It is one class because it is *the* documented public surface: the object
-# `alembic_runner` yields, and the receiver of every call in every example in the docs.
-# Splitting it would rename or re-home names that users have written tests against, for no
-# defect -- the metrics are healthy (no block above `B`, maintainability index `A`), so the
-# split would buy a tidier graph at the cost of an API break.
-#
-# If a genuine reason to split arrives, keep the public names on this class and delegate,
-# rather than asking callers to reach for a second object.
+# This class may seem to be overly large and have a, perhaps, over broad set of responsibilities.
+# However it represents the public API of a migration, containing all the utilities a migration test
+# author (users of this library) should require to manipulate migrations within their tests.
 @dataclass
 class MigrationContext:
     """Within a given environment/execution context, executes alembic commands.


### PR DESCRIPTION
Closes #249.

`runner.py` is the largest module in the package (521 lines, 117 more than `plugin/plugin.py`)
and has the highest in-degree in the import graph — five of seventeen modules import it. And
`MigrationContext` carries both the migration verbs (`migrate_up_one`, `migrate_down_to`,
`roundtrip_next_revision`) and the history/state accessors (`current`, `heads`,
`table_at_revision`, `insert_into`).

Read as a class in isolation, that is two responsibilities and an obvious split. Which is
why it keeps being raised — three assessments in a row have now named it, most recently as
finding 6 of #241.

It is one class because it is *the* documented public surface: the object `alembic_runner`
yields, and the receiver of every call in every documented example. Splitting it renames or
re-homes names users have written tests against, for no defect — no block exceeds `B`,
maintainability index is `A (54.45)`. So this records the decision instead of making the
change, which is the second branch of the issue's `done when`, and points a future split at
delegation behind the existing public names.

A comment rather than a docstring addition, deliberately: the audience is the next person to
propose the split, not the user reading the rendered API page.

No behaviour change. `make lint` clean.
