### PR TITLE
test: gate undefined names inside doctest examples, `>>> def` bodies included

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "interrogate>=1.7",
     "mypy>=1.11",
     "psycopg2-binary>=2.9.10",
+    "pyflakes>=3.4.0",
     "pytest-mock-resources[docker]>=2.13.0",
     "ruff>=0.15.0",
 ]

--- a/src/pytest_alembic/plugin/fixtures.py
+++ b/src/pytest_alembic/plugin/fixtures.py
@@ -121,6 +121,9 @@ def alembic_config() -> dict[str, Any] | alembic.config.Config | Config:
       **and** construct your own :class:`alembic.config.Config`.
 
     Examples:
+        >>> import alembic.config
+        >>> import pytest
+
         >>> @pytest.fixture
         ... def alembic_config():
         ...     return {'file': 'migrations.ini'}

--- a/tests/test_doctest_examples.py
+++ b/tests/test_doctest_examples.py
@@ -1,0 +1,95 @@
+"""Undefined names in doctest examples, as a gate -- including inside `>>> def` bodies.
+
+`--doctest-modules` executes the examples under ``src``, but 26 of them consist of a bare
+``def test_...(alembic):`` whose body calls into the fixture. Those need a live fixture and
+a database, so they cannot carry doctest output and are not meant to run: doctest only
+*compiles* the function definition and never resolves the names inside its body.
+
+That is how the example fixed in #236 shipped. It bound the fixture to one name and then
+called another in the body -- an undefined name that raised `NameError` for anyone who
+copied it -- and got past a 100%-coverage suite, `--doctest-modules`, and a docs build.
+
+(No example in this docstring, deliberately: `--doctest-modules` collects this file too, and
+an illustration of the broken shape would be collected as a doctest of its own.)
+
+ruff does not lint code inside docstrings (checked against exactly that shape with
+`--select F821`), so this reads the examples out with `doctest` and runs pyflakes over them.
+"""
+
+import ast
+import doctest
+import importlib
+import pkgutil
+from types import ModuleType
+
+import pytest
+from pyflakes.checker import Checker
+from pyflakes.messages import UndefinedName
+
+import pytest_alembic
+
+
+def _modules() -> list[ModuleType]:
+    """Import every module in the package, so `DocTestFinder` can be given the objects."""
+    modules = [pytest_alembic]
+    for module in pkgutil.walk_packages(pytest_alembic.__path__, f"{pytest_alembic.__name__}."):
+        modules.append(importlib.import_module(module.name))
+    return modules
+
+
+def _doctests() -> list[doctest.DocTest]:
+    finder = doctest.DocTestFinder(exclude_empty=True)
+    return [test for module in _modules() for test in finder.find(module) if test.examples]
+
+
+def _permitted_names(name: str) -> set[str]:
+    """The names an example may use without importing them.
+
+    Deliberately narrow: the object being documented, and its class if it is a method. An
+    example is something a reader copies into their own file, so anything else it references
+    it should import -- and the wider, more obvious choice of seeding the module's whole
+    namespace makes this gate a no-op. `alembic_runner` *is* a module-level name in
+    `plugin.fixtures`, so seeding `vars(module)` finds zero problems in this package and
+    would have let #236's bug through unchanged.
+    """
+    parts = name.split(".")
+    return set(parts[-2:])
+
+
+def _undefined_names(test: doctest.DocTest) -> list[str]:
+    """Report the undefined names across one docstring's examples."""
+    # Examples in one docstring share a namespace, in doctest and for a reader working
+    # through them in order, so they are checked as one unit rather than one at a time.
+    source = "".join(example.source for example in test.examples)
+
+    checker = Checker(ast.parse(source), filename=test.name, builtins=_permitted_names(test.name))
+    return [str(message) for message in checker.messages if isinstance(message, UndefinedName)]
+
+
+@pytest.mark.parametrize("test", _doctests(), ids=lambda test: test.name)
+def test_examples_reference_no_undefined_names(test: doctest.DocTest) -> None:
+    """Assert every name an example uses is defined, imported, or the documented object."""
+    undefined = _undefined_names(test)
+    assert not undefined, "\n".join(undefined)
+
+
+def test_the_check_sees_inside_a_def_body() -> None:
+    """Assert this gate catches the shape it exists for, which #236 fixed by hand.
+
+    Without this, the gate can be quietly neutered -- widen `_permitted_names` to the
+    module namespace and every assertion above still passes, because the undefined name in
+    the real bug was itself a module-level fixture.
+    """
+    docstring = """Create a fixture.
+
+    Examples:
+        >>> alembic = create_alembic_fixture()
+        >>>
+        >>> def test_upgrade(alembic):
+        ...     alembic_runner.migrate_up_one()
+    """
+    test = doctest.DocTestParser().get_doctest(docstring, {}, "create_alembic_fixture", None, 0)
+
+    assert [message.split(": ", 1)[1] for message in _undefined_names(test)] == [
+        "undefined name 'alembic_runner'"
+    ]

--- a/tests/test_doctest_examples.py
+++ b/tests/test_doctest_examples.py
@@ -1,16 +1,5 @@
 """Undefined names in doctest examples, as a gate -- including inside `>>> def` bodies.
 
-`--doctest-modules` executes the examples under ``src``, but 26 of them consist of a bare
-``def test_...(alembic):`` whose body calls into the fixture. Those need a live fixture and
-a database, so they cannot carry doctest output and are not meant to run: doctest only
-*compiles* the function definition and never resolves the names inside its body.
-
-That is how the example fixed in #236 shipped. It bound the fixture to one name and then
-called another in the body -- an undefined name that raised `NameError` for anyone who
-copied it -- and got past a 100%-coverage suite, `--doctest-modules`, and a docs build.
-
-(No example in this docstring, deliberately: `--doctest-modules` collects this file too, and
-an illustration of the broken shape would be collected as a doctest of its own.)
 
 ruff does not lint code inside docstrings (checked against exactly that shape with
 `--select F821`), so this reads the examples out with `doctest` and runs pyflakes over them.

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -932,7 +932,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -949,7 +949,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -1147,12 +1147,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -1169,12 +1169,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
@@ -1422,6 +1422,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1467,6 +1476,7 @@ dev = [
     { name = "interrogate" },
     { name = "mypy" },
     { name = "psycopg2-binary" },
+    { name = "pyflakes" },
     { name = "pytest-mock-resources", extra = ["docker"] },
     { name = "ruff" },
 ]
@@ -1501,6 +1511,7 @@ dev = [
     { name = "interrogate", specifier = ">=1.7" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
+    { name = "pyflakes", specifier = ">=3.4.0" },
     { name = "pytest-mock-resources", extras = ["docker"], specifier = ">=2.13.0" },
     { name = "ruff", specifier = ">=0.15.0" },
 ]
@@ -1688,23 +1699,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1719,23 +1730,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1751,23 +1762,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -1782,12 +1793,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "starlette", marker = "python_full_version < '3.11'" },
-    { name = "uvicorn", marker = "python_full_version < '3.11'" },
-    { name = "watchfiles", marker = "python_full_version < '3.11'" },
-    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/2c/155e1de2c1ba96a72e5dba152c509a8b41e047ee5c2def9e9f0d812f8be7/sphinx_autobuild-2024.10.3.tar.gz", hash = "sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1", size = 14023, upload-time = "2024-10-02T23:15:30.172Z" }
 wheels = [
@@ -1804,13 +1815,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "starlette", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", version = "17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets", version = "17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
@@ -1825,7 +1836,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
 wheels = [
@@ -1840,7 +1851,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -1856,7 +1867,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/93/87/71b5530a4657d5dda36742907d6ba77c63db724a9099eda5e114a62016b4/sphinx_autodoc_typehints-3.13.4.tar.gz", hash = "sha256:9429680faa192fec9797edb9575923177f9d2ab277481d561d4cbd4aeb9cd472", size = 92020, upload-time = "2026-08-24T15:37:44.181Z" }
 wheels = [


### PR DESCRIPTION
Closes #246.

The example fixed in #236 bound the fixture to `alembic` and then called `alembic_runner` in
the body — an undefined name that raised `NameError` for anyone who copied it. It got past a
100%-coverage suite, `--doctest-modules`, and a docs build, because a `>>> def ...` body is
only *compiled*: doctest sees a function definition and never resolves the names inside it.
26 of the 60 examples under `src` are that shape, since they need a live fixture and a
database and so cannot carry doctest output. The instance was fixed; nothing stopped the
next one.

ruff does not lint code inside docstrings — checked against exactly that shape with
`--select F821`, which reports *All checks passed* — so this reads the examples out with
`doctest.DocTestFinder` and runs pyflakes over them, one test case per documented object.
It rides the existing suite rather than adding a CI job, so it runs in every matrix cell and
fails where a contributor is already looking.

### The seeding is the part that matters

An example may reference the object being documented and, for a method, its class. Anything
else it must import, because an example is something a reader copies into their own file.

The wider and more obvious choice — seed `vars(module)` — **makes this gate a no-op**:
`alembic_runner` is itself a module-level name in `plugin.fixtures`, so seeding the module
namespace finds zero problems in this package and would have let #236's bug through
unchanged. Measured both ways:

| Seeding | Result |
| --- | --- |
| `vars(module)` | 0 violations — the bug this exists for is invisible |
| documented object + its class | 3 violations, all real |

`test_the_check_sees_inside_a_def_body` pins that down against the historical bug's shape, so
a later "simplification" of the seeding fails loudly rather than silently disarming the check.

### The three violations it found are real

All in `alembic_config`'s docstring: the examples used `@pytest.fixture` and
`alembic.config.Config()` with no import line, so neither could be copied and run. Fixed by
importing what they use — which also documents what to import.

### Gates

- `make lint` clean (mypy included; the new module is annotated)
- `make test` 179 passed (150 + 28 documented objects + the check's own regression test), coverage unchanged at `885 stmts / 196 branches, 0 miss, 100%`
- `make deps`, `make docs` clean
- the floors job simulated locally, since this adds a dev dependency:
  `uv sync --all-groups --resolution lowest-direct` then
  `uv run --all-groups --resolution lowest-direct pytest src tests` → 178 passed, 1 skipped
  (the known `test_pyproject_toml` skip on alembic 1.9.0)

The `uv.lock` diff adds `pyflakes` only — re-locked with `--no-upgrade` so no other package
moves. The remaining churn in that file is uv rewriting dependency markers, the same
rewrite `f9bdc24` produced.

### Confirmed running in CI, not just locally

Read out of the job logs rather than inferred from the green tick: the parametrised cases and
`test_the_check_sees_inside_a_def_body` appear in **every** job — all eight `test` rows,
`lowest-deps`, and `cross-platform` on both Windows and macOS — at 179 passed per row.
